### PR TITLE
Ditch virtualenv requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -266,9 +266,6 @@ sphinx-rtd-theme==0.1.9 \
     --hash=sha256:3c38d037713bd78043486eea5bf771d71ed697ec25c09e16f49e44887f7fe184 \
     --hash=sha256:46c2ca8b482b0398b9621bb5a8ec7c9c5c7226926e5363e18d744f5f0d39d78f \
     --hash=sha256:273846f8aacac32bf9542365a593b495b68d8035c2e382c9ccedcac387c9a0a1
-virtualenv==15.1.0 \
-    --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0 \
-    --hash=sha256:02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a
 xmltodict==0.10.2 \
     --hash=sha256:fc518ccf9adbbb917a2ddcb386be852ae6dd36935e1e8b9a3e760201abfdbf77
 pytest-cov==2.4.0 \

--- a/tests/systemtest/run_tests.sh
+++ b/tests/systemtest/run_tests.sh
@@ -7,7 +7,6 @@
 # This runs the system tests. It expects the following things to exist:
 #
 # * "python3" available in PATH
-# * "virtualenv" available in PATH
 #
 # To run this from the root of this repository, do this:
 #
@@ -46,9 +45,8 @@ if [ -z "${ANTENNA_ENV}" ]; then
     exit 1
 fi
 
-# Verify python3 and virtualenv exist
+# Verify python3 exists
 cmd_required python3
-cmd_required virtualenv
 echo "Required commands available."
 
 # If venv exists, exit
@@ -58,7 +56,7 @@ if [ -d "${VENV_DIR}" ]; then
 fi
 
 # Create virtualenv
-virtualenv -p python3 "${VENV_DIR}"
+python3 -m venv "${VENV_DIR}"
 
 # Activate virtualenv
 source "${VENV_DIR}/bin/activate"


### PR DESCRIPTION
Python 3.3+ has virtualenv built-in. This drops the library for the built-in one.