### PR TITLE
Bug 1365416: Fix throttle character checking

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -292,7 +292,7 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         # that.
         if 'uuid' in raw_crash:
             crash_id = raw_crash['uuid']
-            if int(crash_id[-7]) in (ACCEPT, DEFER):
+            if crash_id[-7] in (str(ACCEPT), str(DEFER)):
                 result = int(crash_id[-7])
                 throttle_rate = 100
 


### PR DESCRIPTION
This fixes the throttle character checking code to no longer assume it's an
int-like thing.

Further, it reworks all the tests for getting the throttle result and cleans
them up significantly.