### PR TITLE
Bug 1381713: fix indexerror in is_thunderbird_seamonkey rule

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -245,7 +245,7 @@ mozilla_rules = [
     Rule(
         rule_name='is_thunderbird_seamonkey',
         key='ProductName',
-        condition=lambda x: x[0] in 'TSC',
+        condition=lambda x: x and x[0] in 'TSC',
         percentage=100
     ),
 

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -184,3 +184,11 @@ class Testmozilla_rules:
 
         throttler = Throttler(ConfigManager.from_dict({}))
         assert throttler.throttle(raw_crash) == (DEFER, 'NO_MATCH', 0)
+
+    def test_bad_value(self):
+        raw_crash = {
+            'ProductName': ''
+        }
+
+        throttler = Throttler(ConfigManager.from_dict({}))
+        assert throttler.throttle(raw_crash) == (DEFER, 'NO_MATCH', 0)


### PR DESCRIPTION
This makes sure there's a non-empty ProductName before checking the first
character.