### PR TITLE
Rework docs scripts to build with right permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ANTENNA_ENV ?= "dev.env"
 DC := $(shell which docker-compose)
-UIDGID := $(shell id -u):$(shell id -g)
+HOSTUSER := $(shell id -u):$(shell id -g)
 
 default:
 	@echo "You need to specify a subcommand."
@@ -73,6 +73,6 @@ test-coverage: .docker-build
 	ANTENNA_ENV=empty.env ${DC} run base py.test --cov=antenna --cov-report term-missing
 
 docs: .docker-build
-	ANTENNA_ENV=empty.env ${DC} run -u ${UIDGID} base ./bin/build_docs.sh
+	ANTENNA_ENV=empty.env ${DC} run -u ${HOSTUSER} base ./bin/build_docs.sh
 
 .PHONY: default clean build docs lint run shell test test-system test-system-shell test-coverage

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ANTENNA_ENV ?= "dev.env"
 DC := $(shell which docker-compose)
+UIDGID := $(shell id -u):$(shell id -g)
 
 default:
 	@echo "You need to specify a subcommand."
@@ -72,6 +73,6 @@ test-coverage: .docker-build
 	ANTENNA_ENV=empty.env ${DC} run base py.test --cov=antenna --cov-report term-missing
 
 docs: .docker-build
-	ANTENNA_ENV=empty.env ${DC} run base ./bin/build_docs.sh
+	ANTENNA_ENV=empty.env ${DC} run -u ${UIDGID} base ./bin/build_docs.sh
 
 .PHONY: default clean build docs lint run shell test test-system test-system-shell test-coverage

--- a/bin/build_docs.sh
+++ b/bin/build_docs.sh
@@ -8,12 +8,6 @@
 
 # Clean the docs first
 make -C docs/ clean
-mkdir -p docs/_build/
-chmod -R 777 docs/_build/
 
 # Build the HTML docs
 make -C docs/ html
-
-# Fix permissions
-find docs/_build/ -type d -exec 'chmod' '777' '{}' ';'
-find docs/_build/ -type f -exec 'chmod' '666' '{}' ';'


### PR DESCRIPTION
This redoes "make docs" so that the resulting files have the permissions of the
host user which makes life soooooo much easier.