### PR TITLE
bug 1426949 - rework throttle code

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -288,50 +288,54 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         :returns tuple: ``(result, rule_name, percentage)``
 
         """
-        # If the raw_crash has a uuid, then that implies throttling, so return
-        # that.
-        if 'uuid' in raw_crash:
-            crash_id = raw_crash['uuid']
-            if crash_id[-7] in (str(ACCEPT), str(DEFER)):
-                result = int(crash_id[-7])
+        # FIXME(willkg): We should move some of these things into throttle
+        # rules instead of having them here.
+
+        # Throttle the crash for an initial result
+        result, rule_name, throttle_rate = self.throttler.throttle(raw_crash)
+
+        # If we didn't reject the crash, then go through it and override the
+        # throttle result in certain circumstances.
+        if result != REJECT:
+            if 'uuid' in raw_crash:
+                # If the raw_crash has a uuid, then that implies throttling, so return
+                # that
+                crash_id = raw_crash['uuid']
+                if crash_id[-7] in (str(ACCEPT), str(DEFER)):
+                    result = int(crash_id[-7])
+                    rule_name = 'FROM_CRASHID'
+                    throttle_rate = 100
+
+            elif 'legacy_processing' in raw_crash and 'throttle_rate' in raw_crash:
+                # If we have throttle results for this crash and the values are
+                # valid, then use those instead of the throttle result
+                try:
+                    temp_result = int(raw_crash['legacy_processing'])
+                    if temp_result not in (ACCEPT, DEFER):
+                        raise ValueError('Result is not a valid value: %r', result)
+
+                    temp_throttle_rate = int(raw_crash['throttle_rate'])
+                    if not (0 <= temp_throttle_rate <= 100):
+                        raise ValueError('Throttle rate is not a valid value: %r', result)
+
+                    # The two values are valid, so this becomes our new
+                    # throttle result
+                    result = temp_result
+                    rule_name = 'ALREADY_THROTTLED'
+                    throttle_rate = temp_throttle_rate
+
+                except ValueError:
+                    # If we've gotten a ValueError, it means one or both of the
+                    # values is bad and we should ignore it and move forward
+                    mymetrics.incr('throttle.bad_throttle_values')
+
+            elif raw_crash.get('Throttleable', None) == '0':
+                # If the raw crash has ``Throttleable=0``, then it was
+                # submitted manually, so accept the crash instead of the
+                # throttle result
+                result = ACCEPT
+                rule_name = 'THROTTLEABLE_0'
                 throttle_rate = 100
-
-                # Save the results in the raw_crash itself
-                raw_crash['legacy_processing'] = result
-                raw_crash['throttle_rate'] = throttle_rate
-
-                return result, 'FROM_CRASHID', throttle_rate
-
-        # If we have throttle results for this crash, return those.
-        if 'legacy_processing' in raw_crash and 'throttle_rate' in raw_crash:
-            try:
-                result = int(raw_crash['legacy_processing'])
-                if result not in (ACCEPT, DEFER):
-                    raise ValueError('Result is not a valid value: %r', result)
-
-                throttle_rate = int(raw_crash['throttle_rate'])
-                if not (0 <= throttle_rate <= 100):
-                    raise ValueError('Throttle rate is not a valid value: %r', result)
-                return result, 'ALREADY_THROTTLED', throttle_rate
-
-            except ValueError:
-                # If we've gotten a ValueError, it means one or both of the
-                # values is bad and we should ignore it and move forward.
-                mymetrics.incr('throttle.bad_throttle_values')
-
-        # If we have a Throttleable=0, then return that.
-        if raw_crash.get('Throttleable', None) == '0':
-            # If the raw crash has ``Throttleable=0``, then we accept the
-            # crash.
-            mymetrics.incr('throttleable_0')
-            result = ACCEPT
-            rule_name = 'THROTTLEABLE_0'
-            throttle_rate = 100
-
-        else:
-            # At this stage, nothing has given us a throttle answer, so we
-            # throttle the crash.
-            result, rule_name, throttle_rate = self.throttler.throttle(raw_crash)
 
         # Save the results in the raw_crash itself
         raw_crash['legacy_processing'] = result

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -204,6 +204,12 @@ class TestBreakpadSubmitterResource:
         # throttleable is not 0
         ({'Throttleable': '1'}, (0, 'has_comments', 100)),
         ({'Throttleable': 'foo'}, (0, 'has_comments', 100)),
+
+        # throttler rejects the code and it stays rejected regardless of throttleable value
+        (
+            {'Throttleable': '0', 'HangID': '555', 'ProcessType': 'browser'},
+            (2, 'has_hangid_and_browser', None)
+        ),
     ])
     def test_get_throttle_result(self, data, expected, request_generator):
         data['ProductName'] = 'Firefox'


### PR DESCRIPTION
This reworks the throttle code such that if the throttler rejects the crash, that's the end of it--nothing can override a reject.

The diff for this seems involved, but all it does is move the `self.throttler.throttle()` call to the top and if that returns REJECT, that's the end of that. Beyond that, this cleans up some code so that it flows through better.