### PR TITLE
updates buildid with new release candidates

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -196,10 +196,7 @@ def match_infobar_true(data):
         product == 'Firefox' and
         infobar == 'true' and
         version.startswith(('52.', '53.', '54.', '55.', '56.', '57.', '58.', '59.')) and
-        # FIXME(willkg): buildid is a string that starts with a YYYYMMDD date
-        # so we're doing string compares. Change this to the buildid date when
-        # we push out fixes.
-        buildid < '20180401'
+        buildid < '20171226'
     )
 
 

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -172,7 +172,7 @@ class Testmatch_infobar_true:
         raw_crash = {
             'ProductName': 'Firefox',
             'SubmittedFromInfobar': 'true',
-            'BuildID': '20181212222554',
+            'BuildID': '20171226003912',
             'Version': '57.0'
         }
         assert match_infobar_true(raw_crash) is False


### PR DESCRIPTION
We've produced release candidates for QA with a browser configuration fix for all channels. This adjusts the build id to match to the date. ESR is built with a PST timestamp while the others are build with UTC, so we cannot get more specific than that. 

🎉 🎉 🎉 