### PR TITLE
Update docs on triggering a crash in Firefox

### DIFF
--- a/docs/breakpad_reporting.rst
+++ b/docs/breakpad_reporting.rst
@@ -155,6 +155,8 @@ development instance. There are a few options:
 
    https://addons.mozilla.org/en-US/firefox/addon/crash-me-now-simple/
 
+   This doesn't work with Firefox 57+.
+
 3. Set environment variables:
 
    https://developer.mozilla.org/en-US/docs/Environment_variables_affecting_crash_reporting
@@ -163,20 +165,22 @@ development instance. There are a few options:
 
 4. On Linux, you can crash processes using ``kill``::
 
-       kill -ABRT $(pidof firefox)
+       kill -SIGFPE $(pidof firefox)
 
 
 You can capture a raw HTTP POST this way:
 
-1. Run ``nc -l localhost 8000 > http_post.raw`` in one terminal
+1. Run ``nc -l localhost 8000 > http_post.raw`` in one terminal.
 
-2. Run ``MOZ_CRASHREPORTER_URL=http://localhost:8000/submit firefox`` in a second terminal
+2. Run ``MOZ_CRASHREPORTER_URL=http://localhost:8000/submit firefox`` in a
+   second terminal.
 
-3. Run ``ps -aef``, find the firefox process id and then do ``kill -ABRT <PID>`` in a
-   third terminal
+3. Run ``ps -aef | grep firefox``, find the process id for the main firefox
+   process or a content process, and then do ``kill -SIGFPE <PID>`` in a third
+   terminal.
 
-4. The Firefox process will crash and the crash report dialog will pop up. Make sure
-   to submit the crash, then click on "Quit Firefox" button
+4. The Firefox process will crash and the crash report dialog will pop up.
+   Make sure to submit the crash, then click on "Quit Firefox" button.
 
    That will send the crash to ``nc`` which will pipe it to the file.
 

--- a/docs/breakpad_reporting.rst
+++ b/docs/breakpad_reporting.rst
@@ -141,13 +141,15 @@ Things to know about the HTTP POST response:
      CrashID=bp-28a40956-d19e-48ff-a2ee-19a932160525
 
 
+.. _testing-breakpad-crash-reporting:
+
 Testing breakpad crash reporting
 ================================
 
 When working on Antenna, it helps to be able to send real live crashes to your
 development instance. There are a few options:
 
-1. Use curl:
+1. Use curl to send a crash report to an Antenna instance:
 
    http://socorro.readthedocs.io/en/latest/configuring-socorro.html#test-collection-and-processing
 
@@ -155,29 +157,53 @@ development instance. There are a few options:
 
    https://addons.mozilla.org/en-US/firefox/addon/crash-me-now-simple/
 
-   This doesn't work with Firefox 57+.
+   .. Note::
 
-3. Set environment variables:
+      This doesn't work with Firefox 57+.
+
+3. Use Firefox and set the ``MOZ_CRASHREPORTER_URL`` environment variable:
 
    https://developer.mozilla.org/en-US/docs/Environment_variables_affecting_crash_reporting
 
-   Particularly ``MOZ_CRASHREPORTER_URL``.
 
-4. On Linux, you can crash processes using ``kill``::
+   Then kill the Firefox process using the ``kill`` command.
 
-       kill -SIGFPE $(pidof firefox)
+   1. Run ``ps -aef | grep firefox``. That will list all the
+      Firefox processes.
+
+      Find the process id of the Firefox process you want to kill.
+
+      * main process looks something like ``/usr/bin/firefox``
+      * content process looks something like
+        ``/usr/bin/firefox -contentproc -childID ...``
+
+   2. The ``kill`` command lets you pass a signal to the process. By default, it
+      passes ``SIGTERM`` which will kill the process in a way that doesn't
+      launch the crash reporter.
+
+      You want to kill the process in a way that *does* launch the crash
+      reporter. I've had success with ``SIGABRT`` and ``SIGFPE``. For example:
+
+      * ``kill -SIGABRT <PID>``
+      * ``kill -SIGFPE <PID>``
+
+      What works for you will depend on the operating system and version of
+      Firefox you're using.
 
 
-You can capture a raw HTTP POST this way:
+Capturing an HTTP POST payload for a crash report
+=================================================
+
+The HTTP POST payload for a crash report is sometimes handy to have. You can
+capture it this way:
 
 1. Run ``nc -l localhost 8000 > http_post.raw`` in one terminal.
 
 2. Run ``MOZ_CRASHREPORTER_URL=http://localhost:8000/submit firefox`` in a
    second terminal.
 
-3. Run ``ps -aef | grep firefox``, find the process id for the main firefox
-   process or a content process, and then do ``kill -SIGFPE <PID>`` in a third
-   terminal.
+3. Kill a Firefox process using one of the methods in
+   :ref:`testing-breakpad-crash-reporting`.
 
 4. The Firefox process will crash and the crash report dialog will pop up.
    Make sure to submit the crash, then click on "Quit Firefox" button.


### PR DESCRIPTION
This updates the tips on how to trigger a crash (and a crash report) in
Firefox.