### PR TITLE
fix bug 1409427 - switch to sha256 and add MinidumpSha256 checksum

### DIFF
--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -57,9 +57,6 @@ class TestBreakpadSubmitterResource:
         expected_raw_crash = {
             'ProductName': 'Test',
             'Version': '1.0',
-            'dump_checksums': {
-                'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af',
-            }
         }
         expected_dumps = {
             'upload_file_minidump': b'abcd1234'
@@ -85,10 +82,6 @@ class TestBreakpadSubmitterResource:
         expected_raw_crash = {
             'ProductName': 'Test',
             'Version': '1',
-            'dump_checksums': {
-                'upload_file_minidump': '4f41243847da693a4f356c0486114bc6',
-                'upload_file_minidump_flash1': 'e19d5cd5af0378da05f63f891c7467af',
-            }
         }
         expected_dumps = {
             'upload_file_minidump': b'deadbeef',
@@ -117,9 +110,6 @@ class TestBreakpadSubmitterResource:
         expected_raw_crash = {
             'ProductName': 'Test',
             'Version': '1.0',
-            'dump_checksums': {
-                'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af',
-            }
         }
         expected_dumps = {
             'upload_file_minidump': b'abcd1234'
@@ -138,7 +128,7 @@ class TestBreakpadSubmitterResource:
         # In the dump filename...
         (
             {'ProductName': 'Firefox', '\u0000upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'deadbeef'))},
-            {'ProductName': 'Firefox', 'dump_checksums': {'upload_file_minidump': '4f41243847da693a4f356c0486114bc6'}},
+            {'ProductName': 'Firefox'},
             {'upload_file_minidump': b'deadbeef'}
         )
     ])

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -60,8 +60,11 @@ class TestCrashStorage:
                 'data': {
                     'ProductName': 'Test',
                     'Version': '1.0',
-                    'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
+                    'dump_checksums': {
+                        'upload_file_minidump': 'e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae'
+                    },
                     'legacy_processing': 0,
+                    'MinidumpSha256Hash': 'e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae',
                     'throttle_rate': 100,
                     'submitted_timestamp': '2011-09-06T00:00:00+00:00',
                     'timestamp': 1315267200.0,

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -74,9 +74,11 @@ class TestFSCrashStorage:
         assert (
             contents['/antenna_crashes/20160918/raw_crash/de1bb258-cbbf-4589-a673-34f800160918.json'] ==
             (
-                b'{"ProductName": "Test", ' +
+                b'{"MinidumpSha256Hash": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae", ' +
+                b'"ProductName": "Test", ' +
                 b'"Version": "1.0", ' +
-                b'"dump_checksums": {"upload_file_minidump": "e19d5cd5af0378da05f63f891c7467af"}, ' +
+                b'"dump_checksums": ' +
+                b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, ' +
                 b'"legacy_processing": 0, ' +
                 b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", ' +
                 b'"throttle_rate": 100, ' +
@@ -138,8 +140,11 @@ class TestFSCrashStorage:
             {
                 'uuid': crash_id,
                 'ProductName': 'Test',
+                'MinidumpSha256Hash': 'e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae',
                 'Version': '1.0',
-                'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
+                'dump_checksums': {
+                    'upload_file_minidump': 'e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae'
+                },
                 'legacy_processing': 0,
                 'throttle_rate': 100,
                 'submitted_timestamp': '2011-09-06T00:00:00+00:00',


### PR DESCRIPTION
This switches `dump_checksum` from md5 hexdigest to sha256 hexdigest. We don't use this currently, but sha256 is better and maybe we'll use it for something someday.

This adds a new MinidumpSha256 field with the sha256 hexdigest of the `upload_file_minidump` file.

This also moves the checksum-figuring code out of `extract_payload` and into the `on_post` handler near other code that adds fields to the raw crash.