### PR TITLE
fix bug 1480936: change throttle default to REJECT

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -277,8 +277,8 @@ MOZILLA_RULES = [
         percentage=None
     ),
 
-    # Reject all unsupported products; this does nothing if the list of
-    # supported products is empty
+    # Reject crash reports for unsupported products; this does nothing if the
+    # list of supported products is empty
     Rule(
         rule_name='unsupported_product',
         key='*',
@@ -286,7 +286,15 @@ MOZILLA_RULES = [
         percentage=None
     ),
 
-    # 100% of crashes that have a comment
+    # Accept 100% of crash reports submitted through about:crashes
+    Rule(
+        rule_name='throttleable_0',
+        key='Throttleable',
+        condition=lambda throttler, x: x == '0',
+        percentage=100
+    ),
+
+    # Accept 100% of crash reports that have a comment
     Rule(
         rule_name='has_comments',
         key='Comments',
@@ -294,7 +302,7 @@ MOZILLA_RULES = [
         percentage=100
     ),
 
-    # 100% of crashes that have an email address with at least an @
+    # Accept 100% of crash reports that have an email address with at least an @
     Rule(
         rule_name='has_email',
         key='Email',
@@ -302,7 +310,7 @@ MOZILLA_RULES = [
         percentage=100
     ),
 
-    # 100% of all ReleaseChannel=aurora, beta, esr channels
+    # Accept 100% of crash reports in ReleaseChannel=aurora, beta, esr channels
     Rule(
         rule_name='is_alpha_beta_esr',
         key='ReleaseChannel',
@@ -310,7 +318,7 @@ MOZILLA_RULES = [
         percentage=100
     ),
 
-    # 100% of all ReleaseChannel=nightly
+    # Accept 100% of crash reports in ReleaseChannel=nightly
     Rule(
         rule_name='is_nightly',
         key='ReleaseChannel',
@@ -318,7 +326,7 @@ MOZILLA_RULES = [
         percentage=100
     ),
 
-    # 20% of Firefox 56 and earlier
+    # Accept 20% of Firefox 56 and earlier
     Rule(
         rule_name='firefox_pre_57',
         key='*',
@@ -326,7 +334,7 @@ MOZILLA_RULES = [
         percentage=20
     ),
 
-    # 10% of ProductName=Firefox
+    # Accept 10% of ProductName=Firefox
     Rule(
         rule_name='is_firefox_desktop',
         key='ProductName',
@@ -334,7 +342,7 @@ MOZILLA_RULES = [
         percentage=10
     ),
 
-    # 100% of ProductName=Fennec
+    # Accept 100% of ProductName=Fennec
     Rule(
         rule_name='is_fennec',
         key='ProductName',
@@ -342,15 +350,7 @@ MOZILLA_RULES = [
         percentage=100
     ),
 
-    # 100% of all Version=alpha, beta or special
-    Rule(
-        rule_name='is_version_alpha_beta_special',
-        key='Version',
-        condition=lambda throttler, x: '.' in x and x[-1].isalpha(),
-        percentage=100
-    ),
-
-    # 100% of ProductName=Thunderbird & SeaMonkey
+    # Accept 100% of ProductName=Thunderbird & SeaMonkey
     Rule(
         rule_name='is_thunderbird_seamonkey',
         key='ProductName',

--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -96,7 +96,7 @@ class Throttler(RequiredConfigMixin):
         self.rule_set = self.config('throttle_rules')
 
     def throttle(self, raw_crash):
-        """Go through rule set to ACCEPT, REJECT or DEFER
+        """Go through rule set to ACCEPT, DEFER, or REJECT
 
         :arg dict raw_crash: the crash to throttle
 
@@ -107,14 +107,14 @@ class Throttler(RequiredConfigMixin):
             match = rule.match(self, raw_crash)
 
             if match:
-                if rule.percentage is None:
-                    return REJECT, rule.rule_name, None
+                if rule.result in (ACCEPT, DEFER, REJECT):
+                    return rule.result, rule.rule_name, 100
 
-                if rule.percentage == 100 or (random.random() * 100.0) <= rule.percentage:  # nosec
-                    response = ACCEPT
+                if (random.random() * 100.0) <= rule.result[0]:  # nosec
+                    response = rule.result[1]
                 else:
-                    response = REJECT
-                return response, rule.rule_name, rule.percentage
+                    response = rule.result[2]
+                return response, rule.rule_name, rule.result[0]
 
         # None of the rules matched, so we defer
         return REJECT, 'NO_MATCH', 0
@@ -124,7 +124,7 @@ class Rule:
     """Defines a single rule"""
     RULE_NAME_RE = re.compile(r'^[a-z0-9_]+$', re.I)
 
-    def __init__(self, rule_name, key, condition, percentage):
+    def __init__(self, rule_name, key, condition, result):
         """Creates a Rule
 
         :arg str rule_name: The friendly name for the rule. We use this for
@@ -146,8 +146,24 @@ class Rule:
             This can be any other kind of value which will be compared for equality
             with ``raw_crash[key]``.
 
-        :arg int percentage: The percentage of crashes that match the condition
-            to accept and process.
+        :arg varies result: Can be a single result like ``ACCEPT``, ``DEFER``, or
+            ``REJECT`` in which case any crash report that triggers this rule gets
+            this result.
+
+            Can be a tuple of ``(number, LE_result, GT_result)``. A random number
+            is computed. If it's less than or equal to the number, then the
+            ``LE_result`` is the result. Otherwise the ``GT_result`` is the
+            result.
+
+            Example::
+
+                (10, ACCEPT, REJECT)
+
+                random number: 9 -> ACCEPT
+                              10 -> ACCEPT
+                              11 -> REJECT
+                              72 -> REJECT
+
 
         """
         self.rule_name = rule_name
@@ -155,7 +171,7 @@ class Rule:
         if not callable(condition):
             raise ValueError('condition %r is not callable' % condition)
         self.condition = condition
-        self.percentage = percentage
+        self.result = result
 
         if not self.RULE_NAME_RE.match(self.rule_name):
             raise ValueError('%r is not a valid rule name' % self.rule_name)
@@ -253,7 +269,7 @@ MOZILLA_PRODUCTS = [
 #: Rule set to accept all incoming crashes
 ACCEPT_ALL = [
     # Accept everything
-    Rule('accept_everything', '*', always_match, 100)
+    Rule('accept_everything', '*', always_match, ACCEPT)
 ]
 
 
@@ -266,7 +282,7 @@ MOZILLA_RULES = [
         condition=(
             lambda throttler, d: 'HangID' in d and d.get('ProcessType', 'browser') == 'browser'
         ),
-        percentage=None
+        result=REJECT
     ),
 
     # Reject infobar=true crashes for certain versions of Firefox desktop
@@ -274,7 +290,7 @@ MOZILLA_RULES = [
         rule_name='infobar_is_true',
         key='*',
         condition=match_infobar_true,
-        percentage=None
+        result=REJECT
     ),
 
     # Reject crash reports for unsupported products; this does nothing if the
@@ -283,47 +299,47 @@ MOZILLA_RULES = [
         rule_name='unsupported_product',
         key='*',
         condition=match_unsupported_product,
-        percentage=None
+        result=REJECT
     ),
 
-    # Accept 100% of crash reports submitted through about:crashes
+    # Accept crash reports submitted through about:crashes
     Rule(
         rule_name='throttleable_0',
         key='Throttleable',
         condition=lambda throttler, x: x == '0',
-        percentage=100
+        result=ACCEPT
     ),
 
-    # Accept 100% of crash reports that have a comment
+    # Accept crash reports that have a comment
     Rule(
         rule_name='has_comments',
         key='Comments',
         condition=always_match,
-        percentage=100
+        result=ACCEPT
     ),
 
-    # Accept 100% of crash reports that have an email address with at least an @
+    # Accept crash reports that have an email address with at least an @
     Rule(
         rule_name='has_email',
         key='Email',
         condition=lambda throttler, x: x and '@' in x,
-        percentage=100
+        result=ACCEPT
     ),
 
-    # Accept 100% of crash reports in ReleaseChannel=aurora, beta, esr channels
+    # Accept crash reports in ReleaseChannel=aurora, beta, esr channels
     Rule(
         rule_name='is_alpha_beta_esr',
         key='ReleaseChannel',
         condition=lambda throttler, x: x in ('aurora', 'beta', 'esr'),
-        percentage=100
+        result=ACCEPT
     ),
 
-    # Accept 100% of crash reports in ReleaseChannel=nightly
+    # Accept crash reports in ReleaseChannel=nightly
     Rule(
         rule_name='is_nightly',
         key='ReleaseChannel',
         condition=lambda throttler, x: x.startswith('nightly'),
-        percentage=100
+        result=ACCEPT
     ),
 
     # Accept 20%, reject 80% of Firefox 56 and earlier (all channels)
@@ -331,7 +347,7 @@ MOZILLA_RULES = [
         rule_name='firefox_pre_57',
         key='*',
         condition=match_firefox_pre_57,
-        percentage=20
+        result=(20, ACCEPT, REJECT)
     ),
 
     # Accept 10%, reject 90% of Firefox desktop release channel
@@ -342,7 +358,7 @@ MOZILLA_RULES = [
             data.get('ProductName', '') == 'Firefox' and
             data.get('ReleaseChannel', '') == 'release'
         ),
-        percentage=10
+        result=(10, ACCEPT, REJECT)
     ),
 
     # Accept everything else
@@ -350,6 +366,6 @@ MOZILLA_RULES = [
         rule_name='accept_everything',
         key='*',
         condition=always_match,
-        percentage=100
+        result=ACCEPT
     )
 ]

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -190,13 +190,6 @@ class TestBreakpadSubmitterResource:
 
         # throttle_rate is not valid
         ({'legacy_processing': '0', 'throttle_rate': '1000'}, (0, 'has_comments', 100)),
-
-        # throttleable is 0
-        ({'Throttleable': '0'}, (0, 'THROTTLEABLE_0', 100)),
-
-        # throttleable is not 0
-        ({'Throttleable': '1'}, (0, 'has_comments', 100)),
-        ({'Throttleable': 'foo'}, (0, 'has_comments', 100)),
     ])
     def test_get_throttle_result(self, data, expected, request_generator):
         data['ProductName'] = 'Firefox'

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -10,6 +10,7 @@ import pytest
 from antenna.app import BreakpadSubmitterResource
 from antenna.breakpad_resource import MAX_ATTEMPTS
 from antenna.ext.crashstorage_base import CrashStorageBase
+from antenna.throttler import ACCEPT
 from testlib.mini_poster import compress, multipart_encode
 
 
@@ -27,7 +28,8 @@ class TestBreakpadSubmitterResource:
     def test_submit_crash_report_reply(self, client):
         data, headers = multipart_encode({
             'ProductName': 'Firefox',
-            'Version': '1.0',
+            'Version': '60.0a1',
+            'ReleaseChannel': 'nightly',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
 
@@ -150,7 +152,8 @@ class TestBreakpadSubmitterResource:
         data, headers = multipart_encode({
             'uuid': crash_id,
             'ProductName': 'Firefox',
-            'Version': '1.0',
+            'Version': '60.0a1',
+            'ReleaseChannel': 'nightly',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
 
@@ -165,38 +168,16 @@ class TestBreakpadSubmitterResource:
         # crash id we sent
         assert result.content.decode('utf-8') == 'CrashID=bp-%s\n' % crash_id
 
-    @pytest.mark.parametrize('data, expected', [
-        # FIXME(willkg): This functionality is commented out so we can test throttling
-        # on stage for bug #1476941.
-
-        # # uuid has ACCEPT in throttle character position
-        # ({'uuid': 'de1bb258-cbbf-4589-a673-34f800160918'}, (0, 'FROM_CRASHID', 100)),
-
-        # # uuid has DEFER in throttle character position
-        # ({'uuid': 'de1bb258-cbbf-4589-a673-34f801160918'}, (1, 'FROM_CRASHID', 100)),
-
-        # uuid has bad character in throttle character position, so it doesn't use that throttle
-        # result
-        ({'uuid': 'de1bb258-cbbf-4589-a673-34f80f160918'}, (0, 'has_comments', 100)),
-
-        # legacy_processing and/or throttle_rate has bad value, so it doesn't use that throttle
-        # result
-        ({'legacy_processing': 'foo', 'throttle_rate': 'bar'}, (0, 'has_comments', 100)),
-        ({'legacy_processing': '0', 'throttle_rate': 'bar'}, (0, 'has_comments', 100)),
-        ({'legacy_processing': 'foo', 'throttle_rate': '100'}, (0, 'has_comments', 100)),
-
-        # legacy_processing is not a valid value
-        ({'legacy_processing': '1000', 'throttle_rate': '100'}, (0, 'has_comments', 100)),
-
-        # throttle_rate is not valid
-        ({'legacy_processing': '0', 'throttle_rate': '1000'}, (0, 'has_comments', 100)),
-    ])
-    def test_get_throttle_result(self, data, expected, request_generator):
-        data['ProductName'] = 'Firefox'
-        data['Comments'] = 'foo bar baz'
+    def test_get_throttle_result(self):
+        raw_crash = {
+            'ProductName': 'Firefox',
+            'ReleaseChannel': 'nightly'
+        }
 
         bsp = BreakpadSubmitterResource(self.empty_config)
-        assert bsp.get_throttle_result(data) == expected
+        assert bsp.get_throttle_result(raw_crash) == (ACCEPT, 'is_nightly', 100)
+        assert raw_crash['legacy_processing'] == ACCEPT
+        assert raw_crash['throttle_rate'] == 100
 
     def test_queuing(self, client):
         def check_health(crashmover_pool_size, crashmover_save_queue_size):
@@ -212,7 +193,8 @@ class TestBreakpadSubmitterResource:
         data, headers = multipart_encode({
             'uuid': 'de1bb258-cbbf-4589-a673-34f800160918',
             'ProductName': 'Firefox',
-            'Version': '1.0',
+            'Version': '60.0a1',
+            'ReleaseChannel': 'nightly',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
 
@@ -241,7 +223,8 @@ class TestBreakpadSubmitterResource:
         data, headers = multipart_encode({
             'uuid': crash_id,
             'ProductName': 'Firefox',
-            'Version': '1.0',
+            'Version': '60.0a1',
+            'ReleaseChannel': 'nightly',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
 

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -269,6 +269,27 @@ class Testmozilla_rules:
         # by any of the rules, so it falls through the entire rule set.
         assert throttler.throttle(raw_crash) == (DEFER, 'NO_MATCH', 0)
 
+    def test_throttleable(self, throttler):
+        # Throttleable=0 should match
+        raw_crash = {
+            'ProductName': 'Test',
+            'Throttleable': '0'
+        }
+        assert throttler.throttle(raw_crash) == (ACCEPT, 'throttleable_0', 100)
+
+        # Any other value than "0" should not match
+        raw_crash = {
+            'ProductName': 'Test',
+            'Throttleable': '1'
+        }
+        assert throttler.throttle(raw_crash) != (ACCEPT, 'throttleable_0', 100)
+
+        raw_crash = {
+            'ProductName': 'Test',
+            'Throttleable': 'foo'
+        }
+        assert throttler.throttle(raw_crash) != (ACCEPT, 'throttleable_0', 100)
+
     def test_comments(self, throttler):
         raw_crash = {
             'ProductName': 'Test',
@@ -331,19 +352,6 @@ class Testmozilla_rules:
             'ProductName': 'Fennec'
         }
         assert throttler.throttle(raw_crash) == (ACCEPT, 'is_fennec', 100)
-
-    @pytest.mark.parametrize('version', [
-        '35.0a',
-        '35.0b',
-        '35.0A',
-        '35.0.0a'
-    ])
-    def test_is_version_alpha_beta_special(self, throttler, version):
-        raw_crash = {
-            'ProductName': 'Test',
-            'Version': version
-        }
-        assert throttler.throttle(raw_crash) == (ACCEPT, 'is_version_alpha_beta_special', 100)
 
     @pytest.mark.parametrize('product', [
         'Thunderbird',


### PR DESCRIPTION
This changes the throttle default from `DEFER` to `REJECT`. So instead of
Socorro saving everything even if it's not going to process it, it will
now only save crash data for crash reports it plans to process.