### PR TITLE
fix bug 1476941: reject unsupported products

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -30,8 +30,6 @@ RESULT_TO_TEXT = {
     2: 'REJECT'
 }
 
-REGEXP_TYPE = type(re.compile(''))
-
 
 def parse_attribute(val):
     module, attribute_name = val.rsplit('.', 1)

--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -268,11 +268,11 @@ MOZILLA_RULES = [
     # supported products is empty
     Rule(
         rule_name='unsupported_product',
-        key='ProductName',
+        key='*',
         condition=(
-            lambda throttler, val: (
+            lambda throttler, data: (
                 throttler.config('products') and
-                val not in throttler.config('products')
+                data.get('ProductName', '') not in throttler.config('products')
             )
         ),
         percentage=None

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -26,7 +26,7 @@ class TestBreakpadSubmitterResource:
 
     def test_submit_crash_report_reply(self, client):
         data, headers = multipart_encode({
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
@@ -42,7 +42,7 @@ class TestBreakpadSubmitterResource:
 
     def test_extract_payload(self, request_generator):
         data, headers = multipart_encode({
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
@@ -55,7 +55,7 @@ class TestBreakpadSubmitterResource:
 
         bsp = BreakpadSubmitterResource(self.empty_config)
         expected_raw_crash = {
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
         }
         expected_dumps = {
@@ -65,7 +65,7 @@ class TestBreakpadSubmitterResource:
 
     def test_extract_payload_2_dumps(self, request_generator):
         data, headers = multipart_encode({
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'deadbeef')),
             'upload_file_minidump_flash1': ('fakecrash2.dump', io.BytesIO(b'abcd1234')),
@@ -80,7 +80,7 @@ class TestBreakpadSubmitterResource:
 
         bsp = BreakpadSubmitterResource(self.empty_config)
         expected_raw_crash = {
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1',
         }
         expected_dumps = {
@@ -91,7 +91,7 @@ class TestBreakpadSubmitterResource:
 
     def test_extract_payload_compressed(self, request_generator):
         data, headers = multipart_encode({
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
@@ -108,7 +108,7 @@ class TestBreakpadSubmitterResource:
 
         bsp = BreakpadSubmitterResource(self.empty_config)
         expected_raw_crash = {
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
         }
         expected_dumps = {
@@ -149,7 +149,7 @@ class TestBreakpadSubmitterResource:
         crash_id = 'de1bb258-cbbf-4589-a673-34f800160918'
         data, headers = multipart_encode({
             'uuid': crash_id,
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
@@ -215,7 +215,7 @@ class TestBreakpadSubmitterResource:
 
         data, headers = multipart_encode({
             'uuid': 'de1bb258-cbbf-4589-a673-34f800160918',
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
@@ -244,7 +244,7 @@ class TestBreakpadSubmitterResource:
         crash_id = 'de1bb258-cbbf-4589-a673-34f800160918'
         data, headers = multipart_encode({
             'uuid': crash_id,
-            'ProductName': 'Test',
+            'ProductName': 'Firefox',
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -14,7 +14,8 @@ class TestCrashStorage:
     def test_flow(self, client):
         """Verify posting a crash gets to crash storage in the right shape"""
         client.rebuild_app({
-            'THROTTLE_RULES': 'antenna.throttler.accept_all'
+            'THROTTLE_RULES': 'antenna.throttler.ACCEPT_ALL',
+            'PRODUCTS': 'antenna.throttler.ALL_PRODUCTS'
         })
 
         data, headers = multipart_encode({

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -35,7 +35,8 @@ class TestFSCrashStorage:
         # Rebuild the app the test client is using with relevant configuration.
         client.rebuild_app({
             'BASEDIR': str(tmpdir),
-            'THROTTLE_RULES': 'antenna.throttler.accept_all',
+            'THROTTLE_RULES': 'antenna.throttler.ACCEPT_ALL',
+            'PRODUCTS': 'antenna.throttler.ALL_PRODUCTS',
             'CRASHSTORAGE_CLASS': 'antenna.ext.fs.crashstorage.FSCrashStorage',
             'CRASHSTORAGE_FS_ROOT': str(tmpdir.join('antenna_crashes')),
         })
@@ -113,7 +114,8 @@ class TestFSCrashStorage:
         # Rebuild the app the test client is using with relevant configuration.
         client.rebuild_app({
             'BASEDIR': str(tmpdir),
-            'THROTTLE_RULES': 'antenna.throttler.accept_all',
+            'THROTTLE_RULES': 'antenna.throttler.ACCEPT_ALL',
+            'PRODUCTS': 'antenna.throttler.ALL_PRODUCTS',
             'CRASHSTORAGE_CLASS': 'antenna.ext.fs.crashstorage.FSCrashStorage',
             'CRASHSTORAGE_FS_ROOT': str(tmpdir.join('antenna_crashes')),
         })

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
-
 from everett.manager import ConfigManager
 import pytest
 


### PR DESCRIPTION
This switches the throttler to reject unsupported products. We'll add
products to this list over time as requested.

This also cleans up the throttler. It gets rid of the weirdness around
conditions, so now all conditions are functions. It gets rid of the
one regexp--we could do the same thing without a regexp. It adds
documentation.