### PR TITLE
Add docs requirements files

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+-r ../requirements/default.txt
+-r ../requirements/constraints.txt


### PR DESCRIPTION
ReadTheDocs can only handle one requirements file (as far as I can see), so
this creates one that points at the two files we have in this repo.