### PR TITLE
fix bug 1440031: remove pre-57 throttle rule

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -216,29 +216,6 @@ def match_infobar_true(throttler, data):
     )
 
 
-def match_firefox_pre_57(throttler, data):
-    """Matches crashes for Firefox before 57
-
-    Bug #1433316.
-
-    """
-    product = data.get('ProductName', '')
-    version = data.get('Version', '')
-
-    if not (product and version):
-        return False
-
-    try:
-        major_version = int(version.split('.')[0])
-    except ValueError:
-        return False
-
-    return (
-        product == 'Firefox' and
-        major_version < 57
-    )
-
-
 def match_unsupported_product(throttler, data):
     is_not_supported = (
         throttler.config('products') and
@@ -341,14 +318,6 @@ MOZILLA_RULES = [
         key='ReleaseChannel',
         condition=lambda throttler, x: x.startswith('nightly'),
         result=ACCEPT
-    ),
-
-    # Accept 20%, reject 80% of Firefox 56 and earlier (all channels)
-    Rule(
-        rule_name='firefox_pre_57',
-        key='*',
-        condition=match_firefox_pre_57,
-        result=(20, ACCEPT, REJECT)
     ),
 
     # Accept 10%, reject 90% of Firefox desktop release channel

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -13,7 +13,6 @@ from antenna.throttler import (
     Rule,
     Throttler,
     match_infobar_true,
-    match_firefox_pre_57,
 )
 
 
@@ -165,50 +164,6 @@ class Testmatch_infobar_true:
             'Version': '57.0'
         }
         assert match_infobar_true(throttler, raw_crash) is False
-
-
-class Test_match_firefox_pre_57:
-    @pytest.mark.parametrize('version, expected', [
-        # Before 57 match
-        ('56.0', True),
-        ('56.0.2', True),
-        ('55.0', True),
-        ('5.0', True),
-
-        # 57 and after does not match
-        ('57.0', False),
-        ('57.0.1', False),
-        ('60.0', False),
-
-        # Junk versions don't match
-        ('abc', False),
-    ])
-    def test_versions(self, throttler, version, expected):
-        raw_crash = {
-            'ProductName': 'Firefox',
-            'Version': version
-        }
-        assert match_firefox_pre_57(throttler, raw_crash) == expected
-
-    def test_no_version(self):
-        raw_crash = {
-            'ProductName': 'Firefox',
-        }
-        assert match_firefox_pre_57(throttler, raw_crash) is False
-
-    def test_product(self):
-        # No ProductName
-        raw_crash = {
-            'Version': '56.0'
-        }
-        assert match_firefox_pre_57(throttler, raw_crash) is False
-
-        # ProductName is not Firefox
-        raw_crash = {
-            'ProductName': 'FishSplat',
-            'Version': '56.0'
-        }
-        assert match_firefox_pre_57(throttler, raw_crash) is False
 
 
 class Testmozilla_rules:


### PR DESCRIPTION
We had a rule for throttling pre-57 at 20% rather than the normal 10%.
This helped us catch up with our data after deleting everything.

We no longer need this, so it's time to remove it. This commit does that.