### PR TITLE
fix bug 1500243: add fakeaccept for b2g

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -20,6 +20,7 @@ import markus
 from antenna.heartbeat import register_for_life, register_for_heartbeat
 from antenna.throttler import (
     REJECT,
+    FAKEACCEPT,
     RESULT_TO_TEXT,
     Throttler,
 )
@@ -347,6 +348,11 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         if throttle_result is REJECT:
             # If the result is REJECT, then discard it
             resp.body = 'Discarded=1'
+
+        elif throttle_result is FAKEACCEPT:
+            # If the result is a FAKEACCEPT, then we return a crash id, but throw
+            # the crash away
+            resp.body = 'CrashID=%s%s\n' % (self.config('dump_id_prefix'), crash_id)
 
         else:
             # If the result is not REJECT, then save it and return the CrashID to

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -217,8 +217,9 @@ class Testmozilla_rules:
             # Need a throttler with the default configuration which includes supported
             # products
             throttler = Throttler(ConfigManager.from_dict({}))
-            raw_crash = {}
-            raw_crash['ProductName'] = 'b2g'
+            raw_crash = {
+                'ProductName': 'b2g'
+            }
             assert throttler.throttle(raw_crash) == (FAKEACCEPT, 'b2g', 100)
             assert caplogpp.record_tuples == [
                 ('antenna.throttler', logging.INFO, 'ProductName B2G: fake accept')

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -10,6 +10,7 @@ import pytest
 from antenna.throttler import (
     ACCEPT,
     REJECT,
+    FAKEACCEPT,
     Rule,
     Throttler,
     match_infobar_true,
@@ -195,9 +196,8 @@ class Testmozilla_rules:
         ('firefox', (REJECT, 'unsupported_product', 100)),
         # This product doesn't exist in the list--unsupported
         ('testproduct', (REJECT, 'unsupported_product', 100)),
-        # NOTE(willkg): Other tests test the case where the product name is fine
     ])
-    def test_productname(self, caplogpp, productname, expected):
+    def test_productname_reject(self, caplogpp, productname, expected):
         """Verify productname rule blocks unsupported products"""
         with caplogpp.at_level(logging.INFO, logger='antenna'):
             # Need a throttler with the default configuration which includes supported
@@ -209,6 +209,19 @@ class Testmozilla_rules:
             assert throttler.throttle(raw_crash) == expected
             assert caplogpp.record_tuples == [
                 ('antenna.throttler', logging.INFO, 'ProductName rejected: %r' % productname)
+            ]
+
+    def test_productname_fakeaccept(self, caplogpp):
+        # This product isn't in the list and it's B2G which is the special case
+        with caplogpp.at_level(logging.INFO, logger='antenna'):
+            # Need a throttler with the default configuration which includes supported
+            # products
+            throttler = Throttler(ConfigManager.from_dict({}))
+            raw_crash = {}
+            raw_crash['ProductName'] = 'b2g'
+            assert throttler.throttle(raw_crash) == (FAKEACCEPT, 'b2g', 100)
+            assert caplogpp.record_tuples == [
+                ('antenna.throttler', logging.INFO, 'ProductName B2G: fake accept')
             ]
 
     def test_productname_no_unsupported_products(self):


### PR DESCRIPTION
B2G products send crash reports and will retry ad infinitum on any non-accept.
This fixes the throttler to handle this explicitly by "fake accepting" the
crash. This involves sending an accept-like response, but throwing the crash
away.

We want to be super careful doing this because we're throwing crash data away.
It's ok in this case because we don't want B2G crash data and we don't want
B2G devices to be trying to resend over and over again.