### PR TITLE
fix bug 1527919: use console logging in a local dev environment

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -71,10 +71,14 @@ def setup_logging(app_config):
             'handlers': ['mozlog'],
             'level': 'WARNING',
         },
-        'loggers': {
+    }
+    if app_config('local_dev_env'):
+        # In a local development environment, we log to the console in a
+        # human-readable fashion
+        dc['loggers'] = {
             'antenna': {
                 'propagate': False,
-                'handlers': ['mozlog'],
+                'handlers': ['console'],
                 'level': app_config('logging_level'),
             },
             'markus': {
@@ -82,8 +86,17 @@ def setup_logging(app_config):
                 'handlers': ['console'],
                 'level': 'INFO',
             },
-        },
-    }
+        }
+    else:
+        # In a server environment, we log everything in mozlog format
+        dc['loggers'] = {
+            'antenna': {
+                'propagate': False,
+                'handlers': ['mozlog'],
+                'level': app_config('logging_level'),
+            },
+        }
+
     logging.config.dictConfig(dc)
 
 
@@ -162,6 +175,12 @@ class AppConfig(RequiredConfigMixin):
         'logging_level',
         default='DEBUG',
         doc='The logging level to use. DEBUG, INFO, WARNING, ERROR or CRITICAL'
+    )
+    required_config.add_option(
+        'local_dev_env',
+        default='False',
+        parser=bool,
+        doc='Whether or not this is a local development environment.'
     )
     required_config.add_option(
         'metrics_class',

--- a/dev.env
+++ b/dev.env
@@ -2,6 +2,9 @@
 #
 # See https://antenna.readthedocs.io/ for documentation.
 
+# This marks this as a local development environment
+LOCAL_DEV_ENV=True
+
 # DEBUG is helpful for development, but otherwise we'd use INFO
 LOGGING_LEVEL=DEBUG
 

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -32,6 +32,7 @@ def pytest_runtest_setup():
     setup_logging(ConfigManager.from_dict({
         'HOST_ID': '',
         'LOGGING_LEVEL': 'DEBUG',
+        'LOCAL_DEV_ENV': 'False',
     }))
     markus.configure([
         {'class': 'markus.backends.logging.LoggingMetrics'}


### PR DESCRIPTION
This fixes logging so it uses mozlog in a server environment and console
in a local dev environment. This makes logs muuuuuch easier to read
when working on things.