### PR TITLE
bug 1517807: Fix s3 test class name; remove pytest-env

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -116,8 +116,6 @@ pytest==4.0.2 \
 pytest-cov==2.6.0 \
     --hash=sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7 \
     --hash=sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762
-pytest-env==0.6.2 \
-    --hash=sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2
 pytest-wholenodeid==0.2 \
     --hash=sha256:6bc4edaf560c8b45ac4669bb8b99d8fbbb7f6e5af8dc7727200cd4d3ef4668c2 \
     --hash=sha256:bdcb4df88ca182a19752ef95150c0881deaafc2c593ef67c61515894e5309206

--- a/testlib/s3mock.py
+++ b/testlib/s3mock.py
@@ -5,9 +5,10 @@
 """This module holds bits to make it easier to test Antenna and related scripts.
 
 This contains ``S3Mock`` which is the mocking system we use for recording AWS
-S3 HTTP conversations and writing tests that enforce those conversations. It's
-in this module because at some point, it might make sense to extract this into
-a separate library.
+S3 HTTP conversations and writing tests that enforce those conversations.
+
+It's in this module because at some point, it might make sense to extract this
+into a separate library.
 
 """
 
@@ -235,12 +236,12 @@ class RecordingAdapterShim:
 
 
 class S3Mock:
-    """Provides a configurable mock for Boto3's S3 bits
+    """Provide a configurable mock for Boto3's S3 bits.
 
     Boto3 uses botocore which uses s3transfer which uses requests to do REST
     API calls.
 
-    S3Mock mocks requests by creating a fake adapter which allows it to
+    ``S3Mock`` mocks requests by creating a fake adapter which allows it to
     intercept all outgoing HTTP requests. This lets us do two things:
 
     1. assert HTTP conversations happen in a specified way in tests
@@ -251,7 +252,7 @@ class S3Mock:
 
     **Usage**
 
-    S3Mock is used as a context manager.
+    ``S3Mock`` is used as a context manager.
 
     Basic use::
 
@@ -304,7 +305,7 @@ class S3Mock:
 
     One of the difficulties with writing tests that assert HTTP conversations
     happen in a certain way is that if the conversation happens over SSL, then
-    it's not readable using network sniffing tools. Thus S3Mock provides a
+    it's not readable using network sniffing tools. Thus ``S3Mock`` provides a
     record feature that spits out what's going on to the specified file or
     ``s3mock.log``.
 
@@ -316,12 +317,16 @@ class S3Mock:
             # Do stuff here
 
     """
+
     def __init__(self):
         self.adapter = FakeAdapter()
 
     def __enter__(self):
         self.start_mock()
         return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_mock()
 
     def _get_recording_adapter(self, session, url):
         recording_adapter = RecordingAdapterShim()
@@ -397,9 +402,6 @@ class S3Mock:
     def start_mock(self):
         self._real_get_adapter = requests.Session.get_adapter
         requests.Session.get_adapter = lambda session, url: self.adapter
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.stop_mock()
 
     def stop_mock(self):
         requests.Session.get_adapter = self._real_get_adapter

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -104,8 +104,9 @@ def client():
     This creates an app and a test client that uses that app to submit HTTP
     GET/POST requests.
 
-    If you need it to use an app with a different configuration, you can
-    rebuild the app::
+    The app that's created uses configuration defaults. If you need it to use
+    an app with a different configuration, you can rebuild the app with
+    different configuration::
 
         def test_foo(client, tmpdir):
             client.rebuild_app({

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -10,7 +10,9 @@ import pytest
 from testlib.mini_poster import multipart_encode
 
 
-class TestS3Mock:
+class TestS3CrashStorageIntegration:
+    logging_names = ['antenna']
+
     def test_crash_storage(self, client, s3mock):
         # .verify_bucket_exists() calls HEAD on the bucket to verify it exists
         # and the configuration is correct.
@@ -157,10 +159,6 @@ class TestS3Mock:
 
         # Assert we did the entire s3 conversation
         assert s3mock.remaining_conversation() == []
-
-
-class TestS3MockLogging:
-    logging_names = ['antenna']
 
     def test_retrying(self, client, s3mock, loggingmock):
         ROOT = 'http://fakes3:4569/'


### PR DESCRIPTION
The s3 test class names were weird and there were two classes but only need to be one. This fixes both of those issues.

Antenna isn't using pytest-env, so best to remove it.

This doesn't redo the s3mock stuff altogether, but does fix some minor things with it.