### PR TITLE
fix bug 1359147: fix s3 and pubsub startup and health checks

### DIFF
--- a/antenna/ext/pubsub/crashpublish.py
+++ b/antenna/ext/pubsub/crashpublish.py
@@ -111,6 +111,13 @@ class PubSubCrashPublish(CrashPublishBase):
         future = self.publisher.publish(self.topic_path, data=b'test')
         future.result()
 
+    def check_health(self, state):
+        """Check Pub/Sub connection health."""
+        try:
+            self.publisher.get_topic(self.topic_path)
+        except Exception as exc:
+            state.add_error('PubSubCrashPublish', repr(exc))
+
     def publish_crash(self, crash_report):
         """Publish a crash id to a Pub/Sub topic."""
         crash_id = crash_report.crash_id

--- a/antenna/ext/s3/crashstorage.py
+++ b/antenna/ext/s3/crashstorage.py
@@ -47,15 +47,11 @@ class S3CrashStorage(CrashStorageBase):
     def __init__(self, config):
         self.config = config.with_options(self)
         self.conn = self.config('connection_class')(config)
-        register_for_verification(self.verify_bucket_exists)
+        register_for_verification(self.verify_write_to_bucket)
 
-    def verify_bucket_exists(self):
-        """Verify S3 bucket exists.
-
-        Raises an exception if it doesn't.
-
-        """
-        self.conn.verify_bucket_exists()
+    def verify_write_to_bucket(self):
+        """Verify S3 bucket exists and can be written to."""
+        self.conn.verify_write_to_bucket()
 
     def get_runtime_config(self, namespace=None):
         """Return generator for items in runtime configuration."""

--- a/bin/create_s3_bucket.py
+++ b/bin/create_s3_bucket.py
@@ -59,14 +59,14 @@ def main(args):
     # First, check to see if the bucket is already created.
     try:
         print('Checking to see if bucket "%s" exists...' % conn.bucket)
-        conn.verify_bucket_exists()
+        conn.verify_write_to_bucket()
         print('Bucket exists.')
 
     except ClientError as exc:
         print(str(exc))
-        if 'HeadBucket operation: Not Found' in str(exc):
+        if '(NoSuchBucket)' in str(exc):
             print('Bucket not found. Creating %s ...' % conn.bucket)
-            conn._create_bucket()
+            conn.client.create_bucket(Bucket=conn.bucket)
             print('Bucket created.')
         else:
             raise


### PR DESCRIPTION
This fixes the `S3CrashStorage` startup check to verify that it can write to the S3 bucket instead of just HEADing the bucket which is a different permission.

This also adds a `PubSubCrashPublish` health check which verifies it can access the topic.