### PR TITLE
bug 1538202: remove preload

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ EXPOSE $PORT
 
 CMD $CMD_PREFIX \
     gunicorn \
-    --preload \
     --workers=$GUNICORN_WORKERS \
     --worker-connections=$GUNICORN_WORKER_CONNECTIONS \
     --worker-class=$GUNICORN_WORKER_CLASS \


### PR DESCRIPTION
Gunicorn can preload the entire application before spinning off workers
which saves time and memory. However, it calls gevent monkeypatch after
spinning off the workers, so a bunch of stuff has imported things that
need to be monkeypatched before monkeypatching. I'm pretty sure this
is what's causing the sporadic SystemExits we're seeing.

This shuts off preload.