### PR TITLE
bug 1538202: add monkey.patch_all() calls to guarantee patching

### DIFF
--- a/antenna/ext/pubsub/crashpublish.py
+++ b/antenna/ext/pubsub/crashpublish.py
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# The pubsub code needs monkeypatching to happen before it's imported.
+# This guarantees that.
+from gevent import monkey
+monkey.patch_all()  # noqa
+
 import logging
 import os
 

--- a/antenna/gunicornhooks.py
+++ b/antenna/gunicornhooks.py
@@ -5,8 +5,7 @@
 # Monkey patch stdlib with gevent-friendly bits--need to do this here
 # before we import anything else. Gunicorn does this too late.
 from gevent import monkey
-
-monkey.patch_all()
+monkey.patch_all()  # noqa
 
 
 # We set the timeout here to 60 so as to give Antenna enough time to save off

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Monkey patch stdlib with gevent-friendly bits--need to do this here
+# before we import anything else.
+from gevent import monkey
+monkey.patch_all()  # noqa
+
 import contextlib
 from pathlib import Path
 import logging


### PR DESCRIPTION
This adds a couple of `monkey.patch_all()` calls to guarantee gevent patching
before importing/usage of those things. This should fix issues in the pubsub
code. It also quells a warning when running pytest.