### PR TITLE
bug 1547804: process all ProcessType=gpu crash reports

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -338,6 +338,15 @@ MOZILLA_RULES = [
         result=ACCEPT
     ),
 
+    # Bug #1547804: Accept crash reports from gpu crashes; we don't get many
+    # and our sampling reduces that to a handful that's hard to do things with
+    Rule(
+        rule_name='is_gpu',
+        key='ProcessType',
+        condition=lambda throttler, x: x == 'gpu',
+        result=ACCEPT
+    ),
+
     # Accept crash reports in ReleaseChannel=aurora, beta, esr channels
     Rule(
         rule_name='is_alpha_beta_esr',

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -279,6 +279,20 @@ class Testmozilla_rules:
             raw_crash['Email'] = email
         assert throttler.throttle(raw_crash) == expected
 
+    @pytest.mark.parametrize('processtype, expected', [
+        (None, (ACCEPT, 'accept_everything', 100)),
+        ('', (ACCEPT, 'accept_everything', 100)),
+        ('content', (ACCEPT, 'accept_everything', 100)),
+        ('gpu', (ACCEPT, 'is_gpu', 100))
+    ])
+    def test_gpu(self, throttler, processtype, expected):
+        raw_crash = {
+            'ProductName': 'BarTest',
+        }
+        if processtype:
+            raw_crash['ProcessType'] = processtype
+        assert throttler.throttle(raw_crash) == expected
+
     @pytest.mark.parametrize('channel', [
         'aurora',
         'beta',


### PR DESCRIPTION
The thinking is that we don't get many of these crash reports so we should
process all the ones we do get. I'm estimating this increase processed
crashes per week by about 10,000 which should be fine.