### PR TITLE
bug 1559151: add pyup and set to monthly updates

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,12 @@
+schedule: "every month"
+search: False
+requirements:
+  - requirements/default.txt:
+      update: all
+      pin: true
+  - requirements/contraints.txt:
+      update: all
+      pin: true
+  - docs/requirements.txt:
+      update: all
+      pin: true


### PR DESCRIPTION
In a previous PR, I removed `.pyup.yml` altogether. I think that didn't shut off pyup but rather caused pyup to use the defaults. Then it added a bazillion PRs.

I was thinking about this. Having Antenna not have automated dependency updates was ok when I was maintaining it because I could do a 6-month update manually and that was fine. Making Antenna maintainable by not-me is important. I think switching to a monthly update cycle that's automated is better than no automated update cycle for not-me maintenance.

Thus, this switches it to the same configuration Socorro has.