### PR TITLE
Update pytest and bandit to current versions

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -60,9 +60,9 @@ botocore==1.10.84 \
 
 
 # Development things
-bandit==1.6.1 \
-    --hash=sha256:f89adaff792d1f9b72859784c5f7964c6b5a5f32ca0ca458c9643e02d4fdceac \
-    --hash=sha256:fa1fee3cb60a3dca89b7a86c0be82af0e830def961728aba9290854fe18c1f90
+bandit==1.6.2 \
+    --hash=sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952 \
+    --hash=sha256:41e75315853507aa145d62a78a2a6c5e3240fe14ee7c601459d0df9418196065
 coverage==4.5.3 \
     --hash=sha256:0c5fe441b9cfdab64719f24e9684502a59432df7570521563d7b1aff27ac755f \
     --hash=sha256:2b412abc4c7d6e019ce7c27cbc229783035eef6d5401695dccba80f481be4eb3 \
@@ -111,9 +111,9 @@ flake8==3.7.7 \
 freezegun==0.3.12 \
     --hash=sha256:2a4d9c8cd3c04a201e20c313caf8b6338f1cfa4cda43f46a94cc4a9fd13ea5e7 \
     --hash=sha256:edfdf5bc6040969e6ed2e36eafe277963bdc8b7c01daeda96c5c8594576c9390
-pytest==4.6.3 \
-    --hash=sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45 \
-    --hash=sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da
+pytest==5.0.0 \
+    --hash=sha256:2878de8ae1c79a62c012da6186b88ff0562ea96ce29c4208d2a9b11d9f607df1 \
+    --hash=sha256:95b700cf21ed5b7e91bce7a6b5a573b2e3ef7b3643d00f681d8f9c4672f9fbdf
 pytest-cov==2.7.1 \
     --hash=sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6 \
     --hash=sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a


### PR DESCRIPTION
This replaces pr #350 .

This doesn't update boto3 and friends because that breaks the s3 mock. Bug 1517807 covers that.

This doesn't update falcon because the jump to 2.0 involves some non-trivial reworking of things.