### PR TITLE
Update release.py

### DIFF
--- a/bin/release.py
+++ b/bin/release.py
@@ -13,7 +13,7 @@ both.
 This requires Python 3 to run.
 
 repo: https://github.com/willkg/socorro-release/
-sha: 2a305101822eea54ade497be912eebaa31ef4751
+sha: 6a6ca14d8fc142e3e86d9ac72283ce209edcd1b1
 
 """
 


### PR DESCRIPTION
This updates `release.py` from the socorro-release repo. It looks like nothing happened, but that's because I made changes to this `release.py` when I ran black to reformat the code. I copied the changes back to the socorro-release repo, but need to pick up the SHA change. This does that.