### PR TITLE
bug 1598765: local sqs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ production, see docs_.
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ACCESS_KEY=foo
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_SECRET_ACCESS_KEY=*****
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_REGION=us-east-1
-         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:5000
+         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:4572
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_BUCKET_NAME=antennabucket
 
 

--- a/bin/sqs_cli.py
+++ b/bin/sqs_cli.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# SQS manipulation script.
+#
+# Note: Run this in the base container which has access to SQS.
+#
+# Usage: ./bin/sqs_cli.py [SUBCOMMAND]
+
+import os
+import time
+
+import boto3
+import click
+
+
+VISIBILITY_TIMEOUT = 2
+
+
+class InvalidQueueName(Exception):
+    """Denotes an invalid queue name."""
+
+
+def validate_queue_name(queue_name):
+    if len(queue_name) > 80:
+        raise InvalidQueueName("queue name is too long.")
+
+    for c in queue_name:
+        if not c.isalnum() and c not in "-_":
+            raise InvalidQueueName("%r is not an alphanumeric, - or _ character." % c)
+
+
+def get_client():
+    session = boto3.session.Session(
+        aws_access_key_id=os.environ.get("CRASHPUBLISH_ACCESS_KEY"),
+        aws_secret_access_key=os.environ.get("CRASHPUBLISH_SECRET_ACCESS_KEY"),
+    )
+    client = session.client(
+        service_name="sqs",
+        region_name=os.environ.get("CRASHPUBLISH_REGION"),
+        endpoint_url=os.environ.get("CRASHPUBLISH_ENDPOINT_URL"),
+    )
+    return client
+
+
+@click.group()
+def sqs_group():
+    """Local dev environment SQS manipulation script."""
+
+
+@sqs_group.command("list_messages")
+@click.argument("queue")
+@click.pass_context
+def list_messages(ctx, queue):
+    """List messages in queue."""
+    conn = get_client()
+    try:
+        resp = conn.get_queue_url(QueueName=queue)
+        queue_url = resp["QueueUrl"]
+    except conn.exceptions.QueueDoesNotExist:
+        click.echo("Queue %s does not exist.")
+        return
+
+    # NOTE(willkg): Since the VisibilityTimeout is set to VISIBILITY_TIMEOUT and
+    # messages aren't deleted, items aren't pulled out of the queue permanently.
+    # However, if you run list_messages twice in rapid succession, VisibilityTimeout may
+    # not have passed, so we wait the timeout amount first.
+    time.sleep(VISIBILITY_TIMEOUT)
+
+    is_empty = True
+    while True:
+        resp = conn.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=0, VisibilityTimeout=VISIBILITY_TIMEOUT,
+        )
+        msgs = resp.get("Messages", [])
+        if not msgs:
+            break
+
+        is_empty = False
+        for msg in msgs:
+            click.echo("%s" % msg["Body"])
+
+    if is_empty:
+        click.echo("Queue %s is empty." % queue)
+
+
+@sqs_group.command("send_message")
+@click.argument("queue")
+@click.argument("message")
+@click.pass_context
+def send_message(ctx, queue, message):
+    """Add a message to a queue."""
+    conn = get_client()
+    try:
+        resp = conn.get_queue_url(QueueName=queue)
+        queue_url = resp["QueueUrl"]
+    except conn.exceptions.QueueDoesNotExist:
+        click.echo("Queue %s does not exist.")
+        return
+
+    conn.send_message(QueueUrl=queue_url, MessageBody=message)
+    click.echo("Message sent.")
+
+
+@sqs_group.command("list_queues")
+@click.pass_context
+def list_queues(ctx):
+    """List queues."""
+    conn = get_client()
+    resp = conn.list_queues()
+
+    for queue_url in resp.get("QueueUrls", []):
+        queue_name = queue_url.rsplit("/", 1)[1]
+        click.echo(queue_name)
+
+
+@sqs_group.command("create")
+@click.argument("queue")
+@click.pass_context
+def create(ctx, queue):
+    """Create SQS queue."""
+    conn = get_client()
+    validate_queue_name(queue)
+    try:
+        conn.get_queue_url(QueueName=queue)
+        click.echo("Queue %s already exists." % queue)
+        return
+    except conn.exceptions.QueueDoesNotExist:
+        pass
+    conn.create_queue(QueueName=queue)
+    click.echo("Queue %s created." % queue)
+
+
+@sqs_group.command("delete")
+@click.argument("queue")
+@click.pass_context
+def delete(ctx, queue):
+    """Delete SQS queue."""
+    conn = get_client()
+    try:
+        resp = conn.get_queue_url(QueueName=queue)
+    except conn.exceptions.QueueDoesNotExist:
+        click.echo("Queue %s does not exist." % queue)
+        return
+
+    queue_url = resp["QueueUrl"]
+    conn.delete_queue(QueueUrl=queue_url)
+    click.echo("Queue %s deleted." % queue)
+
+
+if __name__ == "__main__":
+    sqs_group()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
   # https://hub.docker.com/r/localstack/localstack/
   # localstack running a fake S3
   localstack-s3:
-    image: localstack/localstack:0.8.4
+    image: localstack/localstack:0.10.5
     environment:
       - SERVICES=s3:5000
       - DEFAULT_REGION=us-east-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     command: ./bin/run_web.sh
     links:
       - localstack-s3
+      - localstack-sqs
       - statsd
       - pubsub
 
@@ -69,11 +70,24 @@ services:
   localstack-s3:
     image: localstack/localstack:0.10.5
     environment:
-      - SERVICES=s3:5000
+      - SERVICES=s3:4572
       - DEFAULT_REGION=us-east-1
       - HOSTNAME=localstack-s3
+      - HOSTNAME_EXTERNAL=localstack-s3
     ports:
-      - "5000:5000"
+      - "4572:4572"
+
+  # https://hub.docker.com/r/localstack/localstack/
+  # localstack running a fake sqs
+  localstack-sqs:
+    image: localstack/localstack:0.10.5
+    environment:
+      - SERVICES=sqs:4576
+      - DEFAULT_REGION=us-east-1
+      - HOSTNAME=localstack-sqs
+      - HOSTNAME_EXTERNAL=localstack-sqs
+    ports:
+      - "4576:4576"
 
   # https://hub.docker.com/r/kamon/grafana_graphite/
   # username: admin, password: admin

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -32,3 +32,9 @@ CRASHPUBLISH_SUBSCRIPTION_NAME=local_dev_socorro_sub
 
 # Set Pub/Sub library to use emulator
 PUBSUB_EMULATOR_HOST=pubsub:5010
+
+# SQS things for local development
+CRASHPUBLISH_REGION=us-east-1
+CRASHPUBLISH_ACCESS_KEY=foo
+CRASHPUBLISH_SECRET_ACCESS_KEY=foo
+CRASHPUBLISH_ENDPOINT_URL=http://localstack-sqs:4576

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -18,7 +18,7 @@ CRASHSTORAGE_CLASS=antenna.ext.s3.crashstorage.S3CrashStorage
 CRASHPUBLISH_CLASS=antenna.ext.pubsub.crashpublish.PubSubCrashPublish
 
 # S3CrashStorage and S3Connection settings
-CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:5000
+CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:4572
 CRASHSTORAGE_REGION=us-east-1
 CRASHSTORAGE_ACCESS_KEY=foo
 CRASHSTORAGE_SECRET_ACCESS_KEY=foo

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -19,16 +19,14 @@ set -v -e -x
 echo ">>> pytest"
 # Set up environment variables
 
-LOCALSTACK_S3_URL=http://localstack-s3:5000
-PUBSUB_URL=http://pubsub:5010
-
 export PYTHONPATH=/app/:$PYTHONPATH
 PYTEST="$(which pytest)"
 PYTHON="$(which python)"
 
 # Wait for services to be ready
-urlwait "${LOCALSTACK_S3_URL}" 10
-urlwait "${PUBSUB_URL}" 10
+urlwait "${CRASHSTORAGE_ENDPOINT_URL}" 10
+urlwait "http://${PUBSUB_EMULATOR_HOST}" 10
+urlwait "http://localstack-sqs:4576" 10
 
 # Run tests
 "${PYTEST}"

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -26,7 +26,7 @@ PYTHON="$(which python)"
 # Wait for services to be ready
 urlwait "${CRASHSTORAGE_ENDPOINT_URL}" 10
 urlwait "http://${PUBSUB_EMULATOR_HOST}" 10
-urlwait "http://localstack-sqs:4576" 10
+urlwait "${CRASHPUBLISH_ENDPOINT_URL}" 10
 
 # Run tests
 "${PYTEST}"

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -27,7 +27,7 @@ TESTIMAGE="local/antenna_deploy_base"
 
 # Start services in background (this is idempotent)
 echo "Starting services needed by tests in the background..."
-${DC} up -d localstack-s3 statsd pubsub
+${DC} up -d localstack-s3 localstack-sqs statsd pubsub
 
 # If we're running a shell, then we start up a test container with . mounted
 # to /app.
@@ -41,6 +41,7 @@ if [ "$1" == "--shell" ]; then
            --workdir /app \
            --network antenna_default \
            --link antenna_localstack-s3_1 \
+           --link antenna_localstack-sqs_1 \
            --link antenna_statsd_1 \
            --env-file ./docker/config/local_dev.env \
            --tty \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -52,15 +52,12 @@ raven==6.10.0 \
 six==1.13.0 \
     --hash=sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd \
     --hash=sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66
-
-# NOTE(willkg): In order to update these, we have to redo how the s3mock works
-# in the tests.
-boto3==1.10.12 \
-    --hash=sha256:4f231c746d2acba8b458897f7a0a2f4b9d75656eeeba9c78d17f60fa0cc2cb68 \
-    --hash=sha256:e3c67a3b0140b903cc2d64ee9e68a392961a205dc54290000baf928e6a65e25c
-botocore==1.13.12 \
-    --hash=sha256:0095818b1f1e2698c3fe0ccc6bd4ed8c735fce37d9a99d7f304047bfd8272ec8 \
-    --hash=sha256:9303675e019b4a7389bfbec264068435d2111739b46baa7ebd08391e64dddfb4
+boto3==1.10.26 \
+    --hash=sha256:3fe790bf548c5a6a816779cf38eb844b7126c24d0c56be6561dab177f3bb5fba \
+    --hash=sha256:653f0a7d91783d2267017c905ae6252aa9148c6bd1bd333c727de950007860d7
+botocore==1.13.26 \
+    --hash=sha256:9fefb42c6d4fa0079a52b49e5491fa0738cca63649f68be180b3ed6c253d2622 \
+    --hash=sha256:ee55ce128056c5120680d25c8e8dfa3a08dbe7ac3445dc16997daaa68ae4060e
 
 
 # Development things

--- a/tests/unittest/test_bin.py
+++ b/tests/unittest/test_bin.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "bin"))
 
 
 class TestS3Cli:
-    def test_runs(self):
+    def test_basic(self):
         """Basic test to make sure s3_cli imports and runs at all."""
         from s3_cli import s3_group
 
@@ -21,10 +21,20 @@ class TestS3Cli:
 
 
 class TestPubSubCli:
-    def test_runs(self):
+    def test_basic(self):
         """Basic test to make sure pubsub_cli imports and runs at all."""
         from pubsub_cli import pubsub_group
 
         runner = CliRunner()
         result = runner.invoke(pubsub_group, [])
+        assert result.exit_code == 0
+
+
+class TestSQSCli:
+    def test_basic(self):
+        """Basic test to make sure sqs_cli imports and runs at all."""
+        from sqs_cli import sqs_group
+
+        runner = CliRunner()
+        result = runner.invoke(sqs_group, [])
         assert result.exit_code == 0


### PR DESCRIPTION
This:

1. updates localstack to 0.10.5
2. updates boto3 and botocore to their latest versions
3. adds the scaffolding for running an SQS emulator in the local dev environment,
4. adds some configuration for it that doesn't interfere with existing things,
5. adds a cli tool for manipulating SQS state

Of these, the only thing that affects server environments is the boto3/botocore version updates. I didn't see anything specific that would affect Antenna, though, so I think this is just a version bump.