### PR TITLE
Tests fix

### DIFF
--- a/antenna/ext/s3/connection.py
+++ b/antenna/ext/s3/connection.py
@@ -93,7 +93,7 @@ class S3Connection(RequiredConfigMixin):
         default="",
         alternate_keys=["root:aws_access_key_id"],
         doc=(
-            "AWS S3 access key. You can also specify AWS_ACCESS_KEY_ID which is "
+            "AWS access key. You can also specify AWS_ACCESS_KEY_ID which is "
             "the env var used by boto3."
         ),
     )
@@ -102,7 +102,7 @@ class S3Connection(RequiredConfigMixin):
         default="",
         alternate_keys=["root:aws_secret_access_key"],
         doc=(
-            "AWS S3 secret access key. You can also specify AWS_SECRET_ACCESS_KEY "
+            "AWS secret access key. You can also specify AWS_SECRET_ACCESS_KEY "
             "which is the env var used by boto3."
         ),
     )
@@ -110,7 +110,7 @@ class S3Connection(RequiredConfigMixin):
         "region",
         default="us-west-2",
         alternate_keys=["root:s3_region"],
-        doc="AWS S3 region to connect to. For example, ``us-west-2``",
+        doc="AWS region to connect to. For example, ``us-west-2``",
     )
     required_config.add_option(
         "endpoint_url",

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -1,0 +1,5 @@
+# Test environment
+
+# For tests, the default is the no op classes
+CRASHSTORAGE_CLASS=antenna.ext.crashstorage_base.NoOpCrashStorage
+CRASHPUBLISH_CLASS=antenna.ext.crashpublish_base.NoOpCrashPublish

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -44,6 +44,7 @@ if [ "$1" == "--shell" ]; then
            --link antenna_localstack-sqs_1 \
            --link antenna_statsd_1 \
            --env-file ./docker/config/local_dev.env \
+           --env-file ./docker/config/test.env \
            --tty \
            --interactive \
            --entrypoint="" \
@@ -94,6 +95,7 @@ docker run \
        --link antenna_localstack-s3_1 \
        --link antenna_statsd_1 \
        --env-file ./docker/config/local_dev.env \
+       --env-file ./docker/config/test.env \
        --tty \
        --interactive \
        --entrypoint= \

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -65,7 +65,7 @@ class AntennaTestClient(TestClient):
         """Build ConfigManager using environment and overrides."""
         new_config = new_config or {}
         config_manager = ConfigManager(
-            environments=[ConfigDictEnv(new_config), ConfigOSEnv(),]
+            environments=[ConfigDictEnv(new_config), ConfigOSEnv()]
         )
         return config_manager
 

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -40,13 +40,11 @@ class TestCrashStorage:
         # contents of the crash.
 
         # Verify things got saved
-        crashstorage = bsr.crashstorage
-        assert crashstorage.saved_things == [
+        assert bsr.crashstorage.saved_things == [
             {"crash_id": "de1bb258-cbbf-4589-a673-34f800160918"}
         ]
 
         # Verify things got published
-        crashpublish = bsr.crashpublish
-        assert crashpublish.published_things == [
+        assert bsr.crashpublish.published_things == [
             {"crash_id": "de1bb258-cbbf-4589-a673-34f800160918"}
         ]

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -84,13 +84,11 @@ class TestS3CrashStorageIntegration:
     def test_region_and_bucket_with_periods(
         self, client, s3mock, mock_generate_test_filepath
     ):
-        ROOT = "https://s3.us-west-1.amazonaws.com/"
-
         # .verify_write_to_bucket() writes to the bucket to verify Antenna can
         # write to it and the configuration is correct
         s3mock.add_step(
             method="PUT",
-            url=ROOT + "fakebucket.with.periods/test/testwrite.txt",
+            url="http://fakes3:4569/fakebucket.with.periods/test/testwrite.txt",
             body=b"test",
             resp=s3mock.fake_response(status_code=200),
         )
@@ -98,22 +96,28 @@ class TestS3CrashStorageIntegration:
         # We want to verify these files are saved in this specific order.
         s3mock.add_step(
             method="PUT",
-            url=ROOT
-            + "fakebucket.with.periods/v1/dump_names/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket.with.periods/v1/dump_names/"
+                "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             body=b'["upload_file_minidump"]',
             resp=s3mock.fake_response(status_code=200),
         )
         s3mock.add_step(
             method="PUT",
-            url=ROOT
-            + "fakebucket.with.periods/v1/dump/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket.with.periods/v1/dump/"
+                "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             body=b"abcd1234",
             resp=s3mock.fake_response(status_code=200),
         )
         s3mock.add_step(
             method="PUT",
-            url=ROOT
-            + "fakebucket.with.periods/v2/raw_crash/de1/20160918/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket.with.periods/v2/raw_crash/de1/20160918/"
+                "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             # Not going to compare the body here because it's just the raw crash
             resp=s3mock.fake_response(status_code=200),
         )
@@ -130,6 +134,7 @@ class TestS3CrashStorageIntegration:
         client.rebuild_app(
             {
                 "CRASHSTORAGE_CLASS": "antenna.ext.s3.crashstorage.S3CrashStorage",
+                "CRASHSTORAGE_ENDPOINT_URL": "http://fakes3:4569",
                 "CRASHSTORAGE_REGION": "us-west-1",
                 "CRASHSTORAGE_ACCESS_KEY": "fakekey",
                 "CRASHSTORAGE_SECRET_ACCESS_KEY": "fakesecretkey",
@@ -182,13 +187,11 @@ class TestS3CrashStorageIntegration:
         assert s3mock.remaining_conversation() == []
 
     def test_retrying(self, client, s3mock, loggingmock, mock_generate_test_filepath):
-        ROOT = "http://fakes3:4569/"
-
         # .verify_write_to_bucket() writes to the bucket to verify Antenna can
         # write to it and the configuration is correct
         s3mock.add_step(
             method="PUT",
-            url=ROOT + "fakebucket/test/testwrite.txt",
+            url="http://fakes3:4569/fakebucket/test/testwrite.txt",
             body=b"test",
             resp=s3mock.fake_response(status_code=200),
         )
@@ -196,7 +199,10 @@ class TestS3CrashStorageIntegration:
         # Fail once with a 403, retry and then proceed.
         s3mock.add_step(
             method="PUT",
-            url=ROOT + "fakebucket/v1/dump_names/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket/v1/dump_names/"
+                "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             body=b'["upload_file_minidump"]',
             resp=s3mock.fake_response(status_code=403),
         )
@@ -204,20 +210,28 @@ class TestS3CrashStorageIntegration:
         # Proceed with saving files.
         s3mock.add_step(
             method="PUT",
-            url=ROOT + "fakebucket/v1/dump_names/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket/v1/dump_names/"
+                "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             body=b'["upload_file_minidump"]',
             resp=s3mock.fake_response(status_code=200),
         )
         s3mock.add_step(
             method="PUT",
-            url=ROOT + "fakebucket/v1/dump/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket/v1/dump/"
+                "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             body=b"abcd1234",
             resp=s3mock.fake_response(status_code=200),
         )
         s3mock.add_step(
             method="PUT",
-            url=ROOT
-            + "fakebucket/v2/raw_crash/de1/20160918/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket/v2/raw_crash/de1/"
+                "20160918/de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             # Not going to compare the body here because it's just the raw crash
             resp=s3mock.fake_response(status_code=200),
         )


### PR DESCRIPTION
The tests were doing this weird configuration thing where it wasn't pulling from the `local_dev.env` file, but instead ignoring local dev configuration.
    
As we adjust services around, it's easier to have the test environment configured from a file in one place rather than across multiple files.
    
This adjusts the test code to pull from the os environment, adds a `test.env` file, fixes some tests that were curiously broken, and then changes some formatting.

This only affects tests, so if they pass in the local dev environment (they do) and pass in CI (we'll see), then we're good here.
