### PR TITLE
bug 1601455: add AWS SQS crashpublish support

### DIFF
--- a/antenna/ext/s3/connection.py
+++ b/antenna/ext/s3/connection.py
@@ -55,7 +55,8 @@ class S3Connection(RequiredConfigMixin):
 
     **Credentials and permissions**
 
-    When configuring this connection object, you can do one of two things:
+    When configuring credentials for this connection object, you can do one of two
+    things:
 
     1. provide ``ACCESS_KEY`` and ``SECRET_ACCESS_KEY`` in the configuration, OR
     2. use one of the other methods described in the boto3 docs

--- a/antenna/ext/sqs/__init__.py
+++ b/antenna/ext/sqs/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/antenna/ext/sqs/crashpublish.py
+++ b/antenna/ext/sqs/crashpublish.py
@@ -1,0 +1,169 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+import random
+
+import boto3
+from botocore.client import ClientError
+from everett.component import ConfigOptions
+import gevent
+
+from antenna.ext.crashpublish_base import CrashPublishBase
+from antenna.heartbeat import register_for_verification
+from antenna.util import retry
+
+
+logger = logging.getLogger(__name__)
+
+
+def wait_times_connect():
+    """Return generator for wait times with jitter between failed connection attempts."""
+    for i in [5] * 5:
+        yield i + random.uniform(-2, 2)  # nosec
+
+
+class SQSCrashPublish(CrashPublishBase):
+    """Publisher to AWS SQS.
+
+    **Required AWS SQS things**
+
+    When configuring credentials for this crashpublish object, you can do one of two
+    things:
+
+    1. provide ``ACCESS_KEY`` and ``SECRET_ACCESS_KEY`` in the configuration, OR
+    2. use one of the other methods described in the boto3 docs
+       http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
+
+    You also need to create an AWS SQS standard queue with the following settings:
+
+    ==========================  =========
+    Setting                     Value
+    ==========================  =========
+    Default Visibility Timeout  5 minutes
+    Message Retention Period    *default*
+    Maximum Message Size        *default*
+    Delivery Delay              *default*
+    Receive Message Wait Time   *default*
+    ==========================  =========
+
+    The AWS credentials that Antenna is configured with must have the following
+    Amazon SQS permissions on the SQS queue you created:
+
+    * ``sqs:GetQueueUrl``
+
+      Antenna needs to convert a queue name to a queue url. This requires the
+      ``sqs:GetQueueUrl``
+
+    * ``sqs:SendMessage``
+
+      Antenna sends messages to a queue--this is how it publishes crash ids.
+      This requires the ``sqs:SendMessage`` permission.
+
+    If something isn't configured correctly, then Antenna may not start.
+
+
+    **Verification**
+
+    This component verifies that it can publish to the queue by publishing a
+    fake crash id of ``test``. Downstream consumers should ignore these.
+
+    """
+
+    required_config = ConfigOptions()
+    required_config.add_option(
+        "access_key",
+        default="",
+        alternate_keys=["root:aws_access_key_id"],
+        doc=(
+            "AWS SQS access key. You can also specify AWS_ACCESS_KEY_ID which is "
+            "the env var used by boto3."
+        ),
+    )
+    required_config.add_option(
+        "secret_access_key",
+        default="",
+        alternate_keys=["root:aws_secret_access_key"],
+        doc=(
+            "AWS SQS secret access key. You can also specify AWS_SECRET_ACCESS_KEY "
+            "which is the env var used by boto3."
+        ),
+    )
+    required_config.add_option(
+        "region",
+        default="us-west-2",
+        alternate_keys=["root:s3_region"],
+        doc="AWS region to connect to. For example, ``us-west-2``",
+    )
+    required_config.add_option(
+        "endpoint_url",
+        default="",
+        alternate_keys=["root:s3_endpoint_url"],
+        doc=(
+            "endpoint_url to connect to; None if you are connecting to AWS. For "
+            "example, ``http://localhost:4569/``."
+        ),
+    )
+    required_config.add_option("queue_name", doc="The AWS SQS queue name.")
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.queue_name = self.config("queue_name")
+        self.client = self._build_client()
+        self.queue_url = self.client.get_queue_url(QueueName=self.queue_name)[
+            "QueueUrl"
+        ]
+
+        register_for_verification(self.verify_queue)
+
+    @retry(
+        retryable_exceptions=[
+            # FIXME(willkg): Seems like botocore always raises ClientError
+            # which is unhelpful for granularity purposes.
+            ClientError,
+            # This raises a ValueError "invalid endpoint" if it has problems
+            # getting the s3 credentials and then tries "s3..amazonaws.com"--we
+            # want to retry that, too.
+            ValueError,
+        ],
+        wait_time_generator=wait_times_connect,
+        sleep_function=gevent.sleep,
+        module_logger=logger,
+    )
+    def _build_client(self):
+        # Either they provided ACCESS_KEY and SECRET_ACCESS_KEY in which case
+        # we use those, or they didn't in which case boto3 pulls credentials
+        # from one of a myriad of other places.
+        # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
+        session_kwargs = {}
+        if self.config("access_key") and self.config("secret_access_key"):
+            session_kwargs["aws_access_key_id"] = self.config("access_key")
+            session_kwargs["aws_secret_access_key"] = self.config("secret_access_key")
+        session = boto3.session.Session(**session_kwargs)
+
+        kwargs = {
+            "service_name": "sqs",
+            "region_name": self.config("region"),
+        }
+        if self.config("endpoint_url"):
+            kwargs["endpoint_url"] = self.config("endpoint_url")
+
+        return session.client(**kwargs)
+
+    def verify_queue(self):
+        """Verify queue can be published to by publishing fake crash id."""
+        self.client.send_message(QueueUrl=self.queue_url, MessageBody="test")
+
+    def check_health(self, state):
+        """Check AWS SQS connection health."""
+        try:
+            self.client.get_queue_url(QueueName=self.queue_name)
+        except Exception as exc:
+            state.add_error("SQSCrashPublish", repr(exc))
+
+    def publish_crash(self, crash_report):
+        """Publish a crash id to an AWS SQS queue."""
+        crash_id = crash_report.crash_id
+        self.client.send_message(QueueUrl=self.queue_url, MessageBody=crash_id)

--- a/bin/sqs_cli.py
+++ b/bin/sqs_cli.py
@@ -122,6 +122,11 @@ def list_queues(ctx):
 @click.pass_context
 def create(ctx, queue):
     """Create SQS queue."""
+    queue = queue.strip()
+    if not queue:
+        click.echo("Queue name required.")
+        return
+
     conn = get_client()
     validate_queue_name(queue)
     try:
@@ -139,6 +144,11 @@ def create(ctx, queue):
 @click.pass_context
 def delete(ctx, queue):
     """Delete SQS queue."""
+    queue = queue.strip()
+    if not queue:
+        click.echo("Queue name required.")
+        return
+
     conn = get_client()
     try:
         resp = conn.get_queue_url(QueueName=queue)

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -27,7 +27,7 @@ CRASHSTORAGE_BUCKET_NAME=antennabucket
 # Pub/Sub things for local development
 CRASHPUBLISH_SERVICE_ACCOUNT_FILE=
 CRASHPUBLISH_PROJECT_ID=local_dev_socorro
-CRASHPUBLISH_TOPIC_NAME=local_dev_socorro_normal
+CRASHPUBLISH_TOPIC_NAME=local_dev_socorro_standard
 CRASHPUBLISH_SUBSCRIPTION_NAME=local_dev_socorro_sub
 
 # Set Pub/Sub library to use emulator
@@ -38,3 +38,4 @@ CRASHPUBLISH_REGION=us-east-1
 CRASHPUBLISH_ACCESS_KEY=foo
 CRASHPUBLISH_SECRET_ACCESS_KEY=foo
 CRASHPUBLISH_ENDPOINT_URL=http://localstack-sqs:4576
+CRASHPUBLISH_QUEUE_NAME=local_dev_socorro_standard

--- a/docker/run_setup.sh
+++ b/docker/run_setup.sh
@@ -22,3 +22,7 @@ python ./bin/pubsub_cli.py delete_topic "${CRASHPUBLISH_PROJECT_ID}" "${CRASHPUB
 python ./bin/pubsub_cli.py create_topic "${CRASHPUBLISH_PROJECT_ID}" "${CRASHPUBLISH_TOPIC_NAME}"
 python ./bin/pubsub_cli.py create_subscription "${CRASHPUBLISH_PROJECT_ID}" "${CRASHPUBLISH_TOPIC_NAME}" "${CRASHPUBLISH_SUBSCRIPTION_NAME}"
 python ./bin/pubsub_cli.py list_topics "${CRASHPUBLISH_PROJECT_ID}"
+
+echo "Delete and create SQS queue..."
+python ./bin/sqs_cli.py delete "${CRASHPUBLISH_QUEUE_NAME}"
+python ./bin/sqs_cli.py create "${CRASHPUBLISH_QUEUE_NAME}"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -169,10 +169,11 @@ want Antenna to be publishing crash ids somewhere.
    :case: upper
 
 
-Pub/Sub
--------
+Google Pub/Sub
+--------------
 
-The ``PubSubCrashPublish`` class will publish crash ids to a Pub/Sub topic.
+The ``PubSubCrashPublish`` class will publish crash ids to a Google Pub/Sub
+topic.
 
 .. autocomponent:: antenna.ext.pubsub.crashpublish.PubSubCrashPublish
    :show-docstring:
@@ -183,3 +184,17 @@ The ``PubSubCrashPublish`` class will publish crash ids to a Pub/Sub topic.
    for this class is in the ``CRASHPUBLISH`` namespace.
 
    You need to set the project id and topic name.
+
+
+AWS SQS
+-------
+
+The ``SQSCrashPublish`` class will publish crash ids to an AWS SQS queue.
+
+.. autocomponent:: antenna.ext.sqs.crashpublish.SQSCrashPublish
+   :show-docstring:
+   :case: upper
+   :namespace: crashpublish
+
+   When set as the BreakpadSubmitterResource crashpublish class, configuration
+   for this class is in the ``CRASHPUBLISH`` namespace.

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -75,7 +75,8 @@ class AntennaTestClient(TestClient):
         This is helpful if you've changed configuration and need to rebuild the
         app so that components pick up the new configuration.
 
-        :arg new_config: dict of configuration to build the new app with
+        :arg new_config: dict of configuration to override normal values to build the
+            new app with
 
         """
         self.app = get_app(self.build_config(new_config))

--- a/tests/unittest/test_pubsub_crashpublish.py
+++ b/tests/unittest/test_pubsub_crashpublish.py
@@ -90,7 +90,6 @@ class TestPubSubCrashPublishIntegration:
         with pytest.raises(NotFound):
             client.rebuild_app(
                 {
-                    "LOCAL_DEV_ENV": "True",
                     "CRASHPUBLISH_CLASS": "antenna.ext.pubsub.crashpublish.PubSubCrashPublish",
                     "CRASHPUBLISH_PROJECT_ID": "test_socorro",
                     "CRASHPUBLISH_TOPIC_NAME": "test_socorro_normal",
@@ -111,7 +110,6 @@ class TestPubSubCrashPublishIntegration:
         # will call verify_topic() which will work fine.
         client.rebuild_app(
             {
-                "LOCAL_DEV_ENV": "True",
                 "CRASHPUBLISH_CLASS": "antenna.ext.pubsub.crashpublish.PubSubCrashPublish",
                 "CRASHPUBLISH_PROJECT_ID": PROJECT,
                 "CRASHPUBLISH_TOPIC_NAME": TOPIC,
@@ -142,7 +140,6 @@ class TestPubSubCrashPublishIntegration:
         # Rebuild the app the test client is using with relevant configuration
         client.rebuild_app(
             {
-                "LOCAL_DEV_ENV": "True",
                 "CRASHPUBLISH_CLASS": "antenna.ext.pubsub.crashpublish.PubSubCrashPublish",
                 "CRASHPUBLISH_PROJECT_ID": PROJECT,
                 "CRASHPUBLISH_TOPIC_NAME": TOPIC,

--- a/tests/unittest/test_pubsub_crashpublish.py
+++ b/tests/unittest/test_pubsub_crashpublish.py
@@ -92,13 +92,13 @@ class TestPubSubCrashPublishIntegration:
                 {
                     "CRASHPUBLISH_CLASS": "antenna.ext.pubsub.crashpublish.PubSubCrashPublish",
                     "CRASHPUBLISH_PROJECT_ID": "test_socorro",
-                    "CRASHPUBLISH_TOPIC_NAME": "test_socorro_normal",
+                    "CRASHPUBLISH_TOPIC_NAME": "test_socorro_standard",
                 }
             )
 
     def test_verify_topic_with_topic(self, client, pubsub):
         PROJECT = "test_socorro"
-        TOPIC = "test_socorro_normal"
+        TOPIC = "test_socorro_standard"
         SUB = "test_subscription"
 
         pubsub.create_topic(PROJECT, TOPIC)
@@ -122,7 +122,7 @@ class TestPubSubCrashPublishIntegration:
 
     def test_crash_publish(self, client, pubsub):
         PROJECT = "test_socorro"
-        TOPIC = "test_socorro_normal"
+        TOPIC = "test_socorro_standard"
         SUB = "test_subscription"
 
         pubsub.create_topic(PROJECT, TOPIC)

--- a/tests/unittest/test_sqs_crashpublish.py
+++ b/tests/unittest/test_sqs_crashpublish.py
@@ -1,0 +1,131 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import io
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+import pytest
+
+from testlib.mini_poster import multipart_encode
+
+
+class SQSHelper:
+    def __init__(self):
+        self.client = self._build_client()
+        self._queues = []
+
+    def cleanup(self):
+        """Clean up SQS queues creating in tests."""
+        for queue_name in self._queues:
+            queue_url = self.client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+            self.client.delete_queue(QueueUrl=queue_url)
+
+    def _build_client(self):
+        """Build a client."""
+        session = boto3.session.Session(
+            aws_access_key_id=os.environ.get("CRASHPUBLISH_ACCESS_KEY"),
+            aws_secret_access_key=os.environ.get("CRASHPUBLISH_SECRET_ACCESS_KEY"),
+        )
+        client = session.client(
+            service_name="sqs",
+            region_name=os.environ.get("CRASHPUBLISH_REGION"),
+            endpoint_url=os.environ.get("CRASHPUBLISH_ENDPOINT_URL"),
+        )
+        return client
+
+    def create_queue(self, queue_name):
+        """Create a queue."""
+        self.client.create_queue(QueueName=queue_name)
+        self._queues.append(queue_name)
+
+    def get_published_crashids(self, queue_name):
+        """Get crash ids published to the queue."""
+        queue_url = self.client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+        all_crashids = []
+        while True:
+            resp = self.client.receive_message(
+                QueueUrl=queue_url, WaitTimeSeconds=0, VisibilityTimeout=1,
+            )
+            msgs = resp.get("Messages", [])
+            if not msgs:
+                return all_crashids
+            all_crashids.extend([msg["Body"] for msg in msgs])
+
+
+@pytest.fixture
+def sqs():
+    """AWS SQS helper fixture."""
+    sqs = SQSHelper()
+
+    yield sqs
+
+    sqs.cleanup()
+
+
+class TestSQSCrashPublishIntegration:
+    def test_verify_queue_no_queue(self, client, sqs):
+        # Rebuild the app the test client is using with relevant configuration--this
+        # will call verify_queue() which will balk because the queue doesn't exist.
+        with pytest.raises(ClientError):
+            client.rebuild_app(
+                {
+                    "CRASHPUBLISH_CLASS": "antenna.ext.sqs.crashpublish.SQSCrashPublish",
+                    "CRASHPUBLISH_QUEUE_NAME": "test_socorro",
+                }
+            )
+
+    def test_verify_topic_with_queue(self, client, sqs):
+        queue_name = "test_socorro"
+        sqs.create_queue(queue_name)
+
+        # Rebuild the app the test client is using with relevant configuration--this
+        # will call verify_topic() which will work fine.
+        client.rebuild_app(
+            {
+                "CRASHPUBLISH_CLASS": "antenna.ext.sqs.crashpublish.SQSCrashPublish",
+                "CRASHPUBLISH_QUEUE_NAME": "test_socorro",
+            }
+        )
+
+        # Assert "test" crash id was published
+        crashids = sqs.get_published_crashids(queue_name)
+        assert crashids == ["test"]
+
+    def test_crash_publish(self, client, sqs):
+        queue_name = "test_socorro"
+        sqs.create_queue(queue_name)
+
+        data, headers = multipart_encode(
+            {
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+                "ProductName": "Fennec",
+                "Version": "1.0",
+                "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
+            }
+        )
+
+        # Rebuild the app the test client is using with relevant configuration
+        client.rebuild_app(
+            {
+                "CRASHPUBLISH_CLASS": "antenna.ext.sqs.crashpublish.SQSCrashPublish",
+                "CRASHPUBLISH_QUEUE_NAME": "test_socorro",
+            }
+        )
+
+        # Slurp off the "test" crash id from verification
+        sqs.get_published_crashids(queue_name)
+
+        result = client.simulate_post("/submit", headers=headers, body=data)
+        client.join_app()
+
+        # Verify the collector returns a 200 status code and the crash id
+        # we fed it.
+        assert result.status_code == 200
+        assert result.content == b"CrashID=bp-de1bb258-cbbf-4589-a673-34f800160918\n"
+
+        # Assert crash id was published
+        crashids = sqs.get_published_crashids(queue_name)
+        assert crashids == ["de1bb258-cbbf-4589-a673-34f800160918"]


### PR DESCRIPTION
This implements an `SQSCrashPublish` class which publishes crash ids to an AWS SQS standard queue. It includes configuration, tests, and documentation for setting it up.

It is not enabled by default--the default crash publisher is still `NoOpCrashPublish`.

This won't affect production or the local dev environment. This adds the collector bits so that we can then add the processor/webapp bits.