### PR TITLE
Add urlwait calls to docker/run_setup.sh

### DIFF
--- a/docker/run_setup.sh
+++ b/docker/run_setup.sh
@@ -12,6 +12,14 @@
 
 set -e
 
+# Wait for services to be ready
+echo "Waiting for ${CRASHSTORAGE_ENDPOINT_URL} ..."
+urlwait "${CRASHSTORAGE_ENDPOINT_URL}" 10
+echo "Waiting for ${PUBSUB_EMULATOR_HOST} ..."
+urlwait "http://${PUBSUB_EMULATOR_HOST}" 10
+echo "Waiting for ${CRASHPUBLISH_ENDPOINT_URL} ..."
+urlwait "${CRASHPUBLISH_ENDPOINT_URL}" 10
+
 echo "Delete and create S3 bucket..."
 python ./bin/s3_cli.py delete "${CRASHSTORAGE_BUCKET_NAME}"
 python ./bin/s3_cli.py create "${CRASHSTORAGE_BUCKET_NAME}"


### PR DESCRIPTION
`docker/run_setup.sh` requires services to be started. If the machine is fast enough, they may not be running by the time `docker/run_setup.sh` is called which causes it to fail. This reduces that by adding urlwait calls.