### PR TITLE
bug 1608104: add note about annotations in crash report

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -333,6 +333,13 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             # malformed and we should dump it.
             raise MalformedCrashReport("has_json_and_kv")
 
+        # Add a note about how the annotations were encoded in the crash report.
+        # For now, there are two options: json and multipart.
+        if has_json:
+            raw_crash["payload"] = "json"
+        else:
+            raw_crash["payload"] = "multipart"
+
         return raw_crash, dumps
 
     def get_throttle_result(self, raw_crash):

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -59,7 +59,11 @@ class TestBreakpadSubmitterResource:
         )
 
         bsp = BreakpadSubmitterResource(self.empty_config)
-        expected_raw_crash = {"ProductName": "Firefox", "Version": "1.0"}
+        expected_raw_crash = {
+            "ProductName": "Firefox",
+            "Version": "1.0",
+            "payload": "multipart",
+        }
         expected_dumps = {"upload_file_minidump": b"abcd1234"}
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
 
@@ -81,7 +85,11 @@ class TestBreakpadSubmitterResource:
         )
 
         bsp = BreakpadSubmitterResource(self.empty_config)
-        expected_raw_crash = {"ProductName": "Firefox", "Version": "1"}
+        expected_raw_crash = {
+            "ProductName": "Firefox",
+            "Version": "1",
+            "payload": "multipart",
+        }
         expected_dumps = {
             "upload_file_minidump": b"deadbeef",
             "upload_file_minidump_flash1": b"abcd1234",
@@ -115,7 +123,11 @@ class TestBreakpadSubmitterResource:
         )
 
         bsp = BreakpadSubmitterResource(self.empty_config)
-        expected_raw_crash = {"ProductName": "Firefox", "Version": "1.0"}
+        expected_raw_crash = {
+            "ProductName": "Firefox",
+            "Version": "1.0",
+            "payload": "multipart",
+        }
         expected_dumps = {"upload_file_minidump": b"abcd1234"}
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
 
@@ -131,7 +143,11 @@ class TestBreakpadSubmitterResource:
         )
 
         bsp = BreakpadSubmitterResource(self.empty_config)
-        expected_raw_crash = {"ProductName": "Firefox", "Version": "1.0"}
+        expected_raw_crash = {
+            "ProductName": "Firefox",
+            "Version": "1.0",
+            "payload": "json",
+        }
         expected_dumps = {"upload_file_minidump": b"abcd1234"}
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
 

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -78,6 +78,7 @@ class TestFSCrashStorage:
             + b'"dump_checksums": '
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
             + b'"legacy_processing": 0, '
+            + b'"payload": "multipart", '
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
             + b'"throttle_rate": 100, '
             + b'"timestamp": 1315267200.0, '


### PR DESCRIPTION
This adds a note to the raw crash that tells us how the annotations were encoded in the crash report. Were they in a JSON-encoded value in the "extra" field? Were they encoded as key/value pairs in the
multipart/form-data?