### PR TITLE
bug 1604848: reject incoming thunderbird > 68 and seamonkey > 2.49.5

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -238,8 +238,9 @@ def match_seamonkey_gt_2_49_5(throttler, data):
     """
     product = data.get("ProductName", "").lower().strip()
     version = data.get("Version", "")
+    channel = data.get("ReleaseChannel", "")
 
-    if product != "seamonkey" or not version:
+    if product != "seamonkey" or not version or channel != "release":
         return False
 
     try:
@@ -254,15 +255,16 @@ def match_seamonkey_gt_2_49_5(throttler, data):
 
 
 def match_thunderbird_gt_68(throttler, data):
-    """Reject Thunderbird major version > 68 (bug #1604848).
+    """Reject Thunderbird release major version > 68 (bug #1604848).
 
     NOTE(willkg): Remove this January 2021.
 
     """
     product = data.get("ProductName", "").lower().strip()
     version = data.get("Version", "")
+    channel = data.get("ReleaseChannel", "")
 
-    if product != "thunderbird" or not version:
+    if product != "thunderbird" or not version or channel != "release":
         return False
 
     version = version.split(".")[0]

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -188,8 +188,17 @@ class Test_thunderbird_gt_68:
             {"ProductName": "Thunderbird"},
             {"ProductName": "Thunderbird", "Version": ""},
             {"ProductName": "Thunderbird", "Version": "a"},
-            {"ProductName": "Thunderbird", "Version": "66"},
-            {"ProductName": "Thunderbird", "Version": "67.10"},
+            {
+                "ProductName": "Thunderbird",
+                "Version": "66",
+                "ReleaseChannel": "release",
+            },
+            {
+                "ProductName": "Thunderbird",
+                "Version": "67.10",
+                "ReleaseChannel": "release",
+            },
+            {"ProductName": "Thunderbird", "Version": "69.0", "ReleaseChannel": "beta"},
         ],
     )
     def test_false(self, throttler, raw_crash):
@@ -203,7 +212,11 @@ class Test_thunderbird_gt_68:
         # Need a throttler with the default configuration which includes supported
         # products
         throttler = Throttler(ConfigManager.from_dict({}))
-        raw_crash = {"ProductName": "Thunderbird", "Version": version}
+        raw_crash = {
+            "ProductName": "Thunderbird",
+            "Version": version,
+            "ReleaseChannel": "release",
+        }
         assert match_thunderbird_gt_68(throttler, raw_crash) is True
 
 
@@ -216,11 +229,32 @@ class Test_seamonkey_gt_2_49_5:
             {"ProductName": "SeaMonkey"},
             {"ProductName": "SeaMonkey", "Version": ""},
             {"ProductName": "SeaMonkey", "Version": "a"},
-            {"ProductName": "SeaMonkey", "Version": "2"},
-            {"ProductName": "SeaMonkey", "Version": "2.48"},
-            {"ProductName": "SeaMonkey", "Version": "2.49"},
-            {"ProductName": "SeaMonkey", "Version": "2.49.4"},
-            {"ProductName": "SeaMonkey", "Version": "2.49.5"},
+            {"ProductName": "SeaMonkey", "Version": "2", "ReleaseChannel": "release"},
+            {
+                "ProductName": "SeaMonkey",
+                "Version": "2.48",
+                "ReleaseChannel": "release",
+            },
+            {
+                "ProductName": "SeaMonkey",
+                "Version": "2.49",
+                "ReleaseChannel": "release",
+            },
+            {
+                "ProductName": "SeaMonkey",
+                "Version": "2.49.4",
+                "ReleaseChannel": "release",
+            },
+            {
+                "ProductName": "SeaMonkey",
+                "Version": "2.49.5",
+                "ReleaseChannel": "release",
+            },
+            {
+                "ProductName": "SeaMonkey",
+                "Version": "2.51",
+                "ReleaseChannel": "nightly",
+            },
         ],
     )
     def test_false(self, throttler, raw_crash):
@@ -234,7 +268,11 @@ class Test_seamonkey_gt_2_49_5:
         # Need a throttler with the default configuration which includes supported
         # products
         throttler = Throttler(ConfigManager.from_dict({}))
-        raw_crash = {"ProductName": "SeaMonkey", "Version": version}
+        raw_crash = {
+            "ProductName": "SeaMonkey",
+            "Version": version,
+            "ReleaseChannel": "release",
+        }
         assert match_seamonkey_gt_2_49_5(throttler, raw_crash) is True
 
 

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -187,7 +187,7 @@ class Test_thunderbird_gt_68:
             {"ProductName": "Phil"},
             {"ProductName": "Thunderbird"},
             {"ProductName": "Thunderbird", "Version": ""},
-            {"ProductName": "Thunderbird", "Version": "a"},
+            {"ProductName": "Thunderbird", "Version": "a", "ReleaseChannel": "release"},
             {
                 "ProductName": "Thunderbird",
                 "Version": "66",
@@ -248,6 +248,11 @@ class Test_seamonkey_gt_2_49_5:
             {
                 "ProductName": "SeaMonkey",
                 "Version": "2.49.5",
+                "ReleaseChannel": "release",
+            },
+            {
+                "ProductName": "SeaMonkey",
+                "Version": "2.51.0a1",
                 "ReleaseChannel": "release",
             },
             {

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -14,6 +14,8 @@ from antenna.throttler import (
     Rule,
     Throttler,
     match_infobar_true,
+    match_thunderbird_gt_68,
+    match_seamonkey_gt_2_49_5,
 )
 
 
@@ -175,6 +177,65 @@ class Testmatch_infobar_true:
             "Version": "57.0",
         }
         assert match_infobar_true(throttler, raw_crash) is False
+
+
+class Test_thunderbird_gt_68:
+    @pytest.mark.parametrize(
+        "raw_crash",
+        [
+            {},
+            {"ProductName": "Phil"},
+            {"ProductName": "Thunderbird"},
+            {"ProductName": "Thunderbird", "Version": ""},
+            {"ProductName": "Thunderbird", "Version": "a"},
+            {"ProductName": "Thunderbird", "Version": "66"},
+            {"ProductName": "Thunderbird", "Version": "67.10"},
+        ],
+    )
+    def test_false(self, throttler, raw_crash):
+        # Need a throttler with the default configuration which includes supported
+        # products
+        throttler = Throttler(ConfigManager.from_dict({}))
+        assert match_thunderbird_gt_68(throttler, raw_crash) is False
+
+    @pytest.mark.parametrize("version", ["69", "69.0", "70"])
+    def test_true(self, throttler, version):
+        # Need a throttler with the default configuration which includes supported
+        # products
+        throttler = Throttler(ConfigManager.from_dict({}))
+        raw_crash = {"ProductName": "Thunderbird", "Version": version}
+        assert match_thunderbird_gt_68(throttler, raw_crash) is True
+
+
+class Test_seamonkey_gt_2_49_5:
+    @pytest.mark.parametrize(
+        "raw_crash",
+        [
+            {},
+            {"ProductName": "Phil"},
+            {"ProductName": "SeaMonkey"},
+            {"ProductName": "SeaMonkey", "Version": ""},
+            {"ProductName": "SeaMonkey", "Version": "a"},
+            {"ProductName": "SeaMonkey", "Version": "2"},
+            {"ProductName": "SeaMonkey", "Version": "2.48"},
+            {"ProductName": "SeaMonkey", "Version": "2.49"},
+            {"ProductName": "SeaMonkey", "Version": "2.49.4"},
+            {"ProductName": "SeaMonkey", "Version": "2.49.5"},
+        ],
+    )
+    def test_false(self, throttler, raw_crash):
+        # Need a throttler with the default configuration which includes supported
+        # products
+        throttler = Throttler(ConfigManager.from_dict({}))
+        assert match_seamonkey_gt_2_49_5(throttler, raw_crash) is False
+
+    @pytest.mark.parametrize("version", ["2.49.6", "2.50", "3"])
+    def test_true(self, throttler, version):
+        # Need a throttler with the default configuration which includes supported
+        # products
+        throttler = Throttler(ConfigManager.from_dict({}))
+        raw_crash = {"ProductName": "SeaMonkey", "Version": version}
+        assert match_seamonkey_gt_2_49_5(throttler, raw_crash) is True
 
 
 class Testmozilla_rules:


### PR DESCRIPTION
This adds two throttling rules. One rejects incoming Thunderbird crash reports for major version > 68. The other rejects incoming SeaMonkey crash reports > 2.49.5.

This adds notes to remove these rules and remove Thunderbird and SeaMonkey from the supported products in January 2021. It's possible the timeline may change between now and then. If that happens, someone will update the notes.