### PR TITLE
bug 1609440: distinguish between rejections

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -382,7 +382,8 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             # If this is malformed, then reject it with malformed error code.
             msg = str(exc)
             mymetrics.incr("malformed", tags=["reason:%s" % msg])
-            resp.body = "Discarded=%s" % msg
+            resp.status = falcon.HTTP_400
+            resp.body = "Discarded=malformed_%s" % msg
             return
 
         mymetrics.incr("incoming_crash")


### PR DESCRIPTION
This adds "malformed_" as a prefix to the Discarded reason so as to make it possible to distinguish between rejections because the crash report is malformed and rejections because of a rule.

This also changes malformed crash report HTTP responses to have a 400 status code.

To test:

1. run antenna
2. post a bad request:
   ```
   $ curl --verbose -X POST http://localhost:8000/submit
   *   Trying 127.0.0.1:8000...
   * TCP_NODELAY set
   * Connected to localhost (127.0.0.1) port 8000 (#0)
   > POST /submit HTTP/1.1
   > Host: localhost:8000
   > User-Agent: curl/7.65.3
   > Accept: */*
   > 
   * Mark bundle as not supporting multiuse
   < HTTP/1.1 400 Bad Request
   < Server: gunicorn/20.0.4
   < Date: Wed, 15 Jan 2020 16:39:42 GMT
   < Connection: keep-alive
   < content-type: text/plain
   < content-length: 35
   < 
   * Connection #0 to host localhost left intact
   Discarded=malformed_no_content_type
   ```