### PR TITLE
bug 1610540: add code for removing fields

### DIFF
--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -190,6 +190,25 @@ class TestBreakpadSubmitterResource:
         # crash id we sent
         assert result.content.decode("utf-8") == "CrashID=bp-%s\n" % crash_id
 
+    @pytest.mark.parametrize(
+        "raw_crash, expected",
+        [
+            ({}, {"collector_notes": []}),
+            (
+                {"TelemetryClientId": "ou812"},
+                {"collector_notes": ["Removed TelemetryClientId from raw crash."]},
+            ),
+            (
+                {"TelemetryServerURL": "ou812"},
+                {"collector_notes": ["Removed TelemetryServerURL from raw crash."]},
+            ),
+        ],
+    )
+    def test_cleanup_crash_report(self, client, raw_crash, expected):
+        bsp = BreakpadSubmitterResource(self.empty_config)
+        bsp.cleanup_crash_report(raw_crash)
+        assert raw_crash == expected
+
     def test_get_throttle_result(self):
         raw_crash = {"ProductName": "Firefox", "ReleaseChannel": "nightly"}
 

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -75,6 +75,7 @@ class TestFSCrashStorage:
             b'{"MinidumpSha256Hash": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae", '
             + b'"ProductName": "Test", '
             + b'"Version": "1.0", '
+            + b'"collector_notes": [], '
             + b'"dump_checksums": '
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
             + b'"legacy_processing": 0, '


### PR DESCRIPTION
This adds code for removing fields that should never exist in crash reports before the crash reports are saved anywhere.

Currently, this removes `TelemetryClientId` and `TelemetryServerURL`. These are stripped from the crash report before being sent, but in case they aren't, this removes them in the collector.

@jwhitlock wondered why we don't have a schema for what gets accepted and reject anything that's not in the schema. That wasn't doable before, but might be doable now. It's a pretty big change from how we do things currently. It might mean we need a schema per product. It's something we should think about at some point in 2020 or 2021.