### PR TITLE
bug 1614985: handle JSONDecodeError in json value

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -315,7 +315,10 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
                 # This is a JSON blob, so load it and override raw_crash with
                 # it.
                 has_json = True
-                raw_crash = json.loads(fs_item.value)
+                try:
+                    raw_crash = json.loads(fs_item.value)
+                except json.decoder.JSONDecodeError:
+                    raise MalformedCrashReport("bad_json")
 
             elif fs_item.type and (
                 fs_item.type.startswith("application/octet-stream")


### PR DESCRIPTION
If the JSON value kicks up a `JSONDecodeError`, then there's something wrong with the JSON and Antenna should reject the crash report with an error.