### PR TITLE
bug 1618201: fix gunicorn worker class to be configurable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PORT 8000
 ENV GUNICORN_WORKERS 1
 ENV GUNICORN_WORKER_CONNECTIONS 4
+ENV GUNICORN_WORKER_CLASS gevent
 ENV GUNICORN_MAX_REQUESTS 0
 ENV GUNICORN_MAX_REQUESTS_JITTER 0
 ENV CMD_PREFIX ""
@@ -37,7 +38,7 @@ CMD $CMD_PREFIX \
     gunicorn \
     --workers=$GUNICORN_WORKERS \
     --worker-connections=$GUNICORN_WORKER_CONNECTIONS \
-    --worker-class=antenna.gunicornworker.GeventGrpcWorker \
+    --worker-class=$GUNICORN_WORKER_CLASS \
     --max-requests=$GUNICORN_MAX_REQUESTS \
     --max-requests-jitter=$GUNICORN_MAX_REQUESTS_JITTER \
     --config=antenna/gunicornhooks.py \


### PR DESCRIPTION
This was using the old gunicorn worker class that we created to handle making grpcio aware we were using gevent. Now that we're not using Pub/Sub, we aren't using grpcio and thus we don't need that anymore and can go back to the gevent worker.

The infrastructure sets the `GUNICORN_WORKER_CLASS` variable, so we should use that.