### PR TITLE
bug 1381712: wrap fieldstorage call in try/except for bad boundaries

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -293,7 +293,12 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         request_env = dict(req.env)
         request_env["QUERY_STRING"] = ""
 
-        fs = cgi.FieldStorage(fp=data, environ=request_env, keep_blank_values=1)
+        try:
+            fs = cgi.FieldStorage(fp=data, environ=request_env, keep_blank_values=1)
+        except ValueError:
+            # cgi.FieldStorage throws a ValueError if the boundary is not a str;
+            # treat this as an invalid payload
+            raise MalformedCrashReport("malformed_boundary")
 
         raw_crash = {}
         dumps = {}

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -96,6 +96,24 @@ class TestBreakpadSubmitterResource:
         }
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
 
+    def test_extract_payload_bad_boundary(self, request_generator):
+        data, headers = multipart_encode(
+            {
+                "ProductName": "Firefox",
+                "Version": "1.0",
+                "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
+            },
+            # This is a junk non-ascii boundary that causes FieldStorage to raise a
+            # ValueError
+            boundary="\xc3\xbf.",
+        )
+        req = request_generator(
+            method="POST", path="/submit", headers=headers, body=data
+        )
+        bsp = BreakpadSubmitterResource(self.empty_config)
+        with pytest.raises(MalformedCrashReport, match="malformed_boundary"):
+            bsp.extract_payload(req)
+
     def test_extract_payload_bad_content_type(self, request_generator):
         headers = {"Content-Type": "application/json"}
         req = request_generator(


### PR DESCRIPTION
If the parsed boundary is not a `str`, then `cgi.FieldStorage` throws a
`ValueError`. This catches that and throws a `MalformedCrashReport`.