### PR TITLE
bug 1619640: fix UnicodeDecodeError when decoding JSON

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -322,7 +322,10 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
                 has_json = True
                 try:
                     raw_crash = json.loads(fs_item.value)
-                except json.decoder.JSONDecodeError:
+                except (json.decoder.JSONDecodeError, UnicodeDecodeError):
+                    # The UnicodeDecodeError can happen if the utf-8 codec can't decode
+                    # one of the characters. The JSONDecodeError can happen in a variety
+                    # of "malformed JSON" situations.
                     raise MalformedCrashReport("bad_json")
 
             elif fs_item.type and (


### PR DESCRIPTION
If the JSON-encoded value has a bad character in it, it'll kick up a `UnicodeDecodeError`. This adds handling for that situation.