### PR TITLE
bug 1668583: reduce race between services and tests running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,16 @@ lintfix: my.env .docker-build  ## | Reformat code.
 
 .PHONY: test
 test: my.env .docker-build  ## | Run unit tests.
+	# Make sure services are started up
+	${DC} up -d localstack-sqs localstack-s3 statsd
+	# Run tests
 	${DC} run --rm test shell ./docker/run_tests.sh
 
 .PHONY: test-ci
 test-ci: my.env .docker-build  ## | Run unit tests in CI.
+	# Make sure services are started up
+	${DC} up -d localstack-sqs localstack-s3 statsd
+	# Run tests in test-ci container
 	${DC} run --rm test-ci shell ./docker/run_tests.sh
 
 .PHONY: testshell


### PR DESCRIPTION
The service containers can be up, but the services might not be running,
yet. This reduces the likelihood that the tests lose the race.