### PR TITLE
Update docker version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
       - store_artifacts:
           path: /antenna/version.json
 
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
 
       - run:
           name: Get info

--- a/Makefile
+++ b/Makefile
@@ -95,14 +95,18 @@ lintfix: my.env .docker-build  ## | Reformat code.
 .PHONY: test
 test: my.env .docker-build  ## | Run unit tests.
 	# Make sure services are started up
-	${DC} up -d localstack-sqs localstack-s3 statsd
+	${DC} up -d localstack-s3
+	${DC} up -d localstack-sqs
+	${DC} up -d statsd
 	# Run tests
 	${DC} run --rm test shell ./docker/run_tests.sh
 
 .PHONY: test-ci
 test-ci: my.env .docker-build  ## | Run unit tests in CI.
 	# Make sure services are started up
-	${DC} up -d localstack-sqs localstack-s3 statsd
+	${DC} up -d localstack-s3
+	${DC} up -d localstack-sqs
+	${DC} up -d statsd
 	# Run tests in test-ci container
 	${DC} run --rm test-ci shell ./docker/run_tests.sh
 


### PR DESCRIPTION
This explicitly sets the Docker version. If we don't set the version,
CircleCI defaults to using 17.03.0 which is a version that CircleCI is
deprecating.