### PR TITLE
dependency updates 20201102

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim@sha256:3a751ba465936180c83904df83436e835b9a919a6331062ae764deefbd3f3b47
+FROM python:3.9.0-slim@sha256:de73afabeb56845daee86de96e86960d906e975fe7210b6675bf40002eebcc09
 
 # Set up user and group
 ARG groupid=10001

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Production requirements
 boto3==1.15.10
-botocore==1.18.10
+botocore==1.18.18
 datadog==0.39.0
 dockerflow==2020.10.0
 everett==1.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ bandit==1.6.2
 black==20.8b1
 click==7.1.2
 coverage==5.3
-flake8==3.8.3
+flake8==3.8.4
 freezegun==1.0.0
 more-itertools==8.5.0
 pip-tools==5.3.1

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ boto3==1.15.10
 botocore==1.18.18
 datadog==0.39.0
 dockerflow==2020.10.0
-everett==1.0.2
+everett==1.0.3
 falcon==2.0.0
 gevent==20.9.0
 gunicorn==20.0.4

--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ more-itertools==8.5.0
 pip-tools==5.3.1
 pytest-cov==2.10.1
 pytest-wholenodeid==0.2
-pytest==6.1.0
+pytest==6.1.2
 requests==2.24.0
 sphinx-rtd-theme==0.5.0
 urlwait==1.0

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 boto3==1.15.10
 botocore==1.18.10
 datadog==0.39.0
-dockerflow==2020.6.0
+dockerflow==2020.10.0
 everett==1.0.2
 falcon==2.0.0
 gevent==20.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -308,9 +308,9 @@ pytest-wholenodeid==0.2 \
     --hash=sha256:6bc4edaf560c8b45ac4669bb8b99d8fbbb7f6e5af8dc7727200cd4d3ef4668c2 \
     --hash=sha256:bdcb4df88ca182a19752ef95150c0881deaafc2c593ef67c61515894e5309206 \
     # via -r requirements.in
-pytest==6.1.0 \
-    --hash=sha256:1cd09785c0a50f9af72220dd12aa78cfa49cbffc356c61eab009ca189e018a33 \
-    --hash=sha256:d010e24666435b39a4cf48740b039885642b6c273a3f77be3e7e03554d2806b7 \
+pytest==6.1.2 \
+    --hash=sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe \
+    --hash=sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e \
     # via -r requirements.in, pytest-cov, pytest-wholenodeid
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ boto3==1.15.10 \
     --hash=sha256:04ce4665dee58c89b0eee784bbb480fb4346a7baeb1d5611f676ae21fd3f553a \
     --hash=sha256:b12e251dc2adeb020118f1f19f50929359a9586a23012d6a890f8357b9b84e5c \
     # via -r requirements.in
-botocore==1.18.10 \
-    --hash=sha256:33083dc87ba7b4dae8ecd4b019896a5e5cb2626808f52450b6a79def8a54023b \
-    --hash=sha256:5e5bb69e5a5f8a992bd994c1faa302b44d8ba97860e042794e5a8f67e9de4f2a \
+botocore==1.18.18 \
+    --hash=sha256:de5f9fc0c7e88ee7ba831fa27475be258ae09ece99143ed623d3618a3c84ee2c \
+    --hash=sha256:e224754230e7e015836ba20037cac6321e8e2ce9b8627c14d579fcb37249decd \
     # via -r requirements.in, boto3, s3transfer
 certifi==2020.6.20 \
     --hash=sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,9 +119,9 @@ falcon==2.0.0 \
     --hash=sha256:eea593cf466b9c126ce667f6d30503624ef24459f118c75594a69353b6c3d5fc \
     --hash=sha256:f93351459f110b4c1ee28556aef9a791832df6f910bea7b3f616109d534df06b \
     # via -r requirements.in
-flake8==3.8.3 \
-    --hash=sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c \
-    --hash=sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208 \
+flake8==3.8.4 \
+    --hash=sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839 \
+    --hash=sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b \
     # via -r requirements.in
 freezegun==1.0.0 \
     --hash=sha256:02b35de52f4699a78f6ac4518e4cd3390dddc43b0aeb978335a8f270a2d9668b \

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,9 +99,9 @@ docutils==0.16 \
     --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \
     --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc \
     # via sphinx
-everett==1.0.2 \
-    --hash=sha256:66c7991c056fd9b1de54c29e2b5004a30209530faef698d6ecfbf24bfbbdd1fb \
-    --hash=sha256:8a5ee8cdde0ed6b3bbb63249e0e0703d4ad91921107ff198e0868ffce5f7b6bc \
+everett==1.0.3 \
+    --hash=sha256:2c4cb84700a122e5bbc82b1808c22e1f0c17af0c1e0c84711e0e43cb1f7b932d \
+    --hash=sha256:6612917b7bd9c1568a63eabdf04701791f7bb05cbf302eb5dc2b6f1aeb68c61e \
     # via -r requirements.in
 falcon==2.0.0 \
     --hash=sha256:18157af2a4fc3feedf2b5dcc6196f448639acf01c68bc33d4d5a04c3ef87f494 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,9 +91,9 @@ decorator==4.4.2 \
     --hash=sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760 \
     --hash=sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7 \
     # via datadog
-dockerflow==2020.6.0 \
-    --hash=sha256:0336428bc7baba97b96eefcb56edd6dc244aacabef0bd48e1d3121f79297ebe4 \
-    --hash=sha256:39af796e973858a8d37a0264fd6843f41b16851a5eab2ed4e1f5872954dcc4c4 \
+dockerflow==2020.10.0 \
+    --hash=sha256:226086becc436b5a1995348e26c4fb2ad1d4e5dbc10dffec0c675c9a43306c8b \
+    --hash=sha256:36787fa016e5505d71d60c36cd4e0de7b2d1e50059160bd4e93ceb62bb40d3f8 \
     # via -r requirements.in
 docutils==0.16 \
     --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \


### PR DESCRIPTION
Update dependencies. This covers:

* Bump pytest from 6.1.0 to 6.1.2 (from PR #649)
* Bump everett from 1.0.2 to 1.0.3 (from PR #648)
* Bump flake8 from 3.8.3 to 3.8.4 (from PR #647)
* Bump botocore from 1.18.10 to 1.18.18 (from PR #646)
* Bump dockerflow from 2020.6.0 to 2020.10.0 (from PR #645)
* Bump python from 3.8.6-slim to 3.9.0-slim in /docker (from PR #644)
