### PR TITLE
bug 1680046: add payload_compressed annotation

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -243,9 +243,12 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         if content_length == 0:
             raise MalformedCrashReport("no_content_length")
 
+        is_compressed = False
+
         # Decompress payload if it's compressed
         if req.env.get("HTTP_CONTENT_ENCODING") == "gzip":
             mymetrics.incr("gzipped_crash")
+            is_compressed = True
 
             # If the content is gzipped, we pull it out and decompress it. We
             # have to do that here because nginx doesn't have a good way to do
@@ -355,6 +358,9 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             raw_crash["payload"] = "json"
         else:
             raw_crash["payload"] = "multipart"
+
+        # Capture whether the payload was compressed
+        raw_crash["payload_compressed"] = "1" if is_compressed else "0"
 
         return raw_crash, dumps
 

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -63,6 +63,7 @@ class TestBreakpadSubmitterResource:
             "ProductName": "Firefox",
             "Version": "1.0",
             "payload": "multipart",
+            "payload_compressed": "0",
         }
         expected_dumps = {"upload_file_minidump": b"abcd1234"}
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
@@ -89,6 +90,7 @@ class TestBreakpadSubmitterResource:
             "ProductName": "Firefox",
             "Version": "1",
             "payload": "multipart",
+            "payload_compressed": "0",
         }
         expected_dumps = {
             "upload_file_minidump": b"deadbeef",
@@ -145,6 +147,7 @@ class TestBreakpadSubmitterResource:
             "ProductName": "Firefox",
             "Version": "1.0",
             "payload": "multipart",
+            "payload_compressed": "1",
         }
         expected_dumps = {"upload_file_minidump": b"abcd1234"}
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
@@ -165,6 +168,7 @@ class TestBreakpadSubmitterResource:
             "ProductName": "Firefox",
             "Version": "1.0",
             "payload": "json",
+            "payload_compressed": "0",
         }
         expected_dumps = {"upload_file_minidump": b"abcd1234"}
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -80,6 +80,7 @@ class TestFSCrashStorage:
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
             + b'"legacy_processing": 0, '
             + b'"payload": "multipart", '
+            + b'"payload_compressed": "0", '
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
             + b'"throttle_rate": 100, '
             + b'"timestamp": 1315267200.0, '


### PR DESCRIPTION
This annotation captures whether the incoming payload was compressed or
not at ingestion.