### PR TITLE
Updates 20201201

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ coverage==5.3
 flake8==3.8.4
 freezegun==1.0.0
 more-itertools==8.5.0
-pip-tools==5.3.1
+pip-tools==5.4.0
 pytest-cov==2.10.1
 pytest-wholenodeid==0.2
 pytest==6.1.2

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ markus==2.2.0
 raven==6.10.0
 
 # Development requirements
-Sphinx==3.2.1
+Sphinx==3.3.1
 bandit==1.6.2
 black==20.8b1
 click==7.1.2

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ click==7.1.2
 coverage==5.3
 flake8==3.8.4
 freezegun==1.0.0
-more-itertools==8.5.0
+more-itertools==8.6.0
 pip-tools==5.4.0
 pytest-cov==2.10.1
 pytest-wholenodeid==0.2

--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,6 @@ pip-tools==5.3.1
 pytest-cov==2.10.1
 pytest-wholenodeid==0.2
 pytest==6.1.2
-requests==2.24.0
+requests==2.25.0
 sphinx-rtd-theme==0.5.0
 urlwait==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -252,9 +252,9 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
     # via flake8
-more-itertools==8.5.0 \
-    --hash=sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20 \
-    --hash=sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c \
+more-itertools==8.6.0 \
+    --hash=sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330 \
+    --hash=sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf \
     # via -r requirements.in
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \

--- a/requirements.txt
+++ b/requirements.txt
@@ -390,9 +390,9 @@ sphinx-rtd-theme==0.5.0 \
     --hash=sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d \
     --hash=sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82 \
     # via -r requirements.in
-sphinx==3.2.1 \
-    --hash=sha256:321d6d9b16fa381a5306e5a0b76cd48ffbc588e6340059a729c6fdd66087e0e8 \
-    --hash=sha256:ce6fd7ff5b215af39e2fcd44d4a321f6694b4530b6f2b2109b64d120773faea0 \
+sphinx==3.3.1 \
+    --hash=sha256:1e8d592225447104d1172be415bc2972bd1357e3e12fdc76edf2261105db4300 \
+    --hash=sha256:d4e59ad4ea55efbb3c05cde3bfc83bfc14f0c95aa95c3d75346fcce186a47960 \
     # via -r requirements.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \

--- a/requirements.txt
+++ b/requirements.txt
@@ -272,9 +272,9 @@ pbr==5.5.0 \
     --hash=sha256:14bfd98f51c78a3dd22a1ef45cf194ad79eee4a19e8e1a0d5c7f8e81ffe182ea \
     --hash=sha256:5adc0f9fc64319d8df5ca1e4e06eea674c26b80e6f00c530b18ce6a6592ead15 \
     # via stevedore
-pip-tools==5.3.1 \
-    --hash=sha256:5672c2b6ca0f1fd803f3b45568c2cf7fadf135b4971e7d665232b2075544c0ef \
-    --hash=sha256:73787e23269bf8a9230f376c351297b9037ed0d32ab0f9bef4a187d976acc054 \
+pip-tools==5.4.0 \
+    --hash=sha256:a4d3990df2d65961af8b41dacc242e600fdc8a65a2e155ed3d2fc18a5c209f20 \
+    --hash=sha256:b73f76fe6464b95e41d595a9c0302c55a786dbc54b63ae776c540c04e31914fb \
     # via -r requirements.in
 pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -366,9 +366,9 @@ regex==2020.9.27 \
     --hash=sha256:f1b3afc574a3db3b25c89161059d857bd4909a1269b0b3cb3c904677c8c4a3f7 \
     --hash=sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f \
     # via black
-requests==2.24.0 \
-    --hash=sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b \
-    --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898 \
+requests==2.25.0 \
+    --hash=sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8 \
+    --hash=sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998 \
     # via -r requirements.in, datadog, sphinx
 s3transfer==0.3.3 \
     --hash=sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13 \


### PR DESCRIPTION
Update dependencies. This covers:

* Bump sphinx from 3.2.1 to 3.3.1 (from PR #655)
* Bump more-itertools from 8.5.0 to 8.6.0 (from PR #654)
* Bump pip-tools from 5.3.1 to 5.4.0 (from PR #653)
* Bump requests from 2.24.0 to 2.25.0 (from PR #652)
