### PR TITLE
bug #1687987: remove unhelpful added fields from raw crash

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -374,7 +374,6 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         result, rule_name, throttle_rate = self.throttler.throttle(raw_crash)
 
         # Save the results in the raw_crash itself
-        raw_crash["legacy_processing"] = result
         raw_crash["throttle_rate"] = throttle_rate
 
         return result, rule_name, throttle_rate

--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -111,9 +111,6 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         doc="The name of the field in the POST data for dumps.",
     )
     required_config.add_option(
-        "dump_id_prefix", default="bp-", doc="The crash type prefix."
-    )
-    required_config.add_option(
         "concurrent_crashmovers",
         default="2",
         parser=positive_int,
@@ -456,8 +453,6 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             )
             raw_crash["uuid"] = crash_id
 
-        raw_crash["type_tag"] = self.config("dump_id_prefix").strip("-")
-
         # Log the throttle result
         logger.info(
             "%s: matched by %s; returned %s",
@@ -478,7 +473,7 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         # If the result is a FAKEACCEPT, then we return a crash id, but throw the crash
         # away
         if throttle_result is FAKEACCEPT:
-            resp.body = "CrashID=%s%s\n" % (self.config("dump_id_prefix"), crash_id)
+            resp.body = "CrashID=bp-%s\n" % crash_id
             return
 
         # If we're accepting the cash report, then clean it up, save it and return the
@@ -488,7 +483,7 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         crash_report.set_state(STATE_SAVE)
         self.crashmover_queue.append(crash_report)
         self.hb_run_crashmover()
-        resp.body = "CrashID=%s%s\n" % (self.config("dump_id_prefix"), crash_id)
+        resp.body = "CrashID=bp-%s\n" % crash_id
 
     def hb_run_crashmover(self):
         """Spawn a crashmover if there's work to do."""

--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -379,9 +379,6 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         # throttle the crash.
         result, rule_name, throttle_rate = self.throttler.throttle(raw_crash)
 
-        # Save the results in the raw_crash itself
-        raw_crash["throttle_rate"] = throttle_rate
-
         return result, rule_name, throttle_rate
 
     def cleanup_crash_report(self, raw_crash):

--- a/antenna/util.py
+++ b/antenna/util.py
@@ -44,6 +44,22 @@ def utc_now():
     return datetime.datetime.now(UTC)
 
 
+def isoformat_to_time(data):
+    """Convert an isoformat string to seconds since epoch
+
+    :arg str data: datetime in isoformat
+
+    :returns: time in seconds as a float (equivalent to time.time() return); or 0.0
+        if it's a bad datetime
+
+    """
+    try:
+        dt = datetime.datetime.fromisoformat(data)
+        return dt.timestamp()
+    except ValueError:
+        return 0.0
+
+
 def get_version_info(basedir):
     """Given a basedir, retrieves version information for this deploy.
 

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -248,7 +248,6 @@ class TestBreakpadSubmitterResource:
 
         bsp = BreakpadSubmitterResource(self.empty_config)
         assert bsp.get_throttle_result(raw_crash) == (ACCEPT, "is_nightly", 100)
-        assert raw_crash["throttle_rate"] == 100
 
     def test_queuing(self, client):
         def check_health(crashmover_pool_size, crashmover_queue_size):

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -248,7 +248,6 @@ class TestBreakpadSubmitterResource:
 
         bsp = BreakpadSubmitterResource(self.empty_config)
         assert bsp.get_throttle_result(raw_crash) == (ACCEPT, "is_nightly", 100)
-        assert raw_crash["legacy_processing"] == ACCEPT
         assert raw_crash["throttle_rate"] == 100
 
     def test_queuing(self, client):

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -82,7 +82,6 @@ class TestFSCrashStorage:
             + b'"payload_compressed": "0", '
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
             + b'"throttle_rate": 100, '
-            + b'"timestamp": 1315267200.0, '
             + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918"}'
         )
 

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -84,7 +84,6 @@ class TestFSCrashStorage:
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
             + b'"throttle_rate": 100, '
             + b'"timestamp": 1315267200.0, '
-            + b'"type_tag": "bp", '
             + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918"}'
         )
 

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -81,7 +81,6 @@ class TestFSCrashStorage:
             + b'"payload": "multipart", '
             + b'"payload_compressed": "0", '
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
-            + b'"throttle_rate": 100, '
             + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918"}'
         )
 

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -78,7 +78,6 @@ class TestFSCrashStorage:
             + b'"collector_notes": [], '
             + b'"dump_checksums": '
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
-            + b'"legacy_processing": 0, '
             + b'"payload": "multipart", '
             + b'"payload_compressed": "0", '
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '

--- a/tests/unittest/test_util.py
+++ b/tests/unittest/test_util.py
@@ -13,6 +13,7 @@ from antenna.util import (
     get_date_from_crash_id,
     get_throttle_from_crash_id,
     get_version_info,
+    isoformat_to_time,
     retry,
     sanitize_dump_name,
     utc_now,
@@ -25,6 +26,19 @@ def test_utc_now():
     assert res.strftime("%Z") == "UTC"
     assert res.strftime("%z") == "+0000"
     assert res.tzinfo
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # Good dates return good times
+        ("2011-09-06T00:00:00+00:00", 1315267200.0),
+        # Bad data returns 0.0
+        ("foo", 0.0),
+    ],
+)
+def test_isoformat_to_time(data, expected):
+    assert isoformat_to_time(data) == expected
 
 
 def test_get_version_info(tmpdir):


### PR DESCRIPTION
Antenna adds a bunch of fields to the raw crash to help us understand what happened at ingestion. This removes the following:

* type_tag -- we don't use this
* legacy_processing -- this isn't helpful since we don't need to distinguish between ACCEPT and DEFER anymore
* throttle_rate -- this isn't interesting to know after the fact
* timestamp -- we can use submitted_timestamp to calculate how long it took to collect the crash