### PR TITLE
bug 1688905: add Email to list of fields we drop at ingestion

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -39,8 +39,10 @@ MAX_ATTEMPTS = 20
 STATE_SAVE = "save"
 STATE_PUBLISH = "publish"
 
-#: Bad fields we should never save
+#: Bad fields we should never save, so remove them from the payload before
+#: they get any further
 BAD_FIELDS = [
+    "Email",
     "TelemetryClientId",
     "TelemetryServerURL",
     "TelemetrySessionId",

--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -349,13 +349,6 @@ MOZILLA_RULES = [
     Rule(
         rule_name="has_comments", key="Comments", condition=always_match, result=ACCEPT
     ),
-    # Accept crash reports that have an email address with at least an @
-    Rule(
-        rule_name="has_email",
-        key="Email",
-        condition=lambda throttler, x: x and "@" in x,
-        result=ACCEPT,
-    ),
     # Bug #1547804: Accept crash reports from gpu crashes; we don't get many
     # and our sampling reduces that to a handful that's hard to do things with
     Rule(

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -335,21 +335,6 @@ class Testmozilla_rules:
         assert throttler.throttle(raw_crash) == (ACCEPT, "has_comments", 100)
 
     @pytest.mark.parametrize(
-        "email, expected",
-        [
-            (None, (ACCEPT, "accept_everything", 100)),
-            ("", (ACCEPT, "accept_everything", 100)),
-            ("foo", (ACCEPT, "accept_everything", 100)),
-            ("foo@example.com", (ACCEPT, "has_email", 100)),
-        ],
-    )
-    def test_email(self, throttler, email, expected):
-        raw_crash = {"ProductName": "BarTest"}
-        if email is not None:
-            raw_crash["Email"] = email
-        assert throttler.throttle(raw_crash) == expected
-
-    @pytest.mark.parametrize(
         "processtype, expected",
         [
             (None, (ACCEPT, "accept_everything", 100)),


### PR DESCRIPTION
This adds `Email` to the list of fields that we drop at ingestion so it doesn't get saved in our system.