### PR TITLE
bug 1699236: end support for Fennec

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -282,7 +282,6 @@ ALL_PRODUCTS = []
 MOZILLA_PRODUCTS = [
     "Firefox",
     "Fenix",
-    "Fennec",
     "FirefoxReality",
     "Focus",
     "GeckoViewExample",

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -54,7 +54,7 @@ class TestS3CrashStorageIntegration:
         data, headers = multipart_encode(
             {
                 "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
-                "ProductName": "Fennec",
+                "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
             }
@@ -125,7 +125,7 @@ class TestS3CrashStorageIntegration:
         data, headers = multipart_encode(
             {
                 "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
-                "ProductName": "Fennec",
+                "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
             }
@@ -239,7 +239,7 @@ class TestS3CrashStorageIntegration:
         data, headers = multipart_encode(
             {
                 "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
-                "ProductName": "Fennec",
+                "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
             }

--- a/tests/unittest/test_sqs_crashpublish.py
+++ b/tests/unittest/test_sqs_crashpublish.py
@@ -103,7 +103,7 @@ class TestSQSCrashPublishIntegration:
         data, headers = multipart_encode(
             {
                 "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
-                "ProductName": "Fennec",
+                "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
             }


### PR DESCRIPTION
This changes Antenna to reject incoming crash reports for Fennec.