### PR TITLE
Bump flake8 from 3.9.0 to 3.9.1 (from PR #707)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ bandit==1.7.0
 black==21.4b2
 click==7.1.2
 coverage==5.5
-flake8==3.9.0
+flake8==3.9.1
 freezegun==1.1.0
 more-itertools==8.7.0
 pip-tools==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -148,9 +148,9 @@ falcon==2.0.0 \
     --hash=sha256:eea593cf466b9c126ce667f6d30503624ef24459f118c75594a69353b6c3d5fc \
     --hash=sha256:f93351459f110b4c1ee28556aef9a791832df6f910bea7b3f616109d534df06b
     # via -r requirements.in
-flake8==3.9.0 \
-    --hash=sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff \
-    --hash=sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0
+flake8==3.9.1 \
+    --hash=sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378 \
+    --hash=sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a
     # via -r requirements.in
 freezegun==1.1.0 \
     --hash=sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3 \


### PR DESCRIPTION
Update dependencies. This covers:

* Bump flake8 from 3.9.0 to 3.9.1 (from PR #707)
