### PR TITLE
Updates 20210601 2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ raven==6.10.0
 Sphinx==3.5.4
 bandit==1.7.0
 black==21.5b2
-click==7.1.2
+click==8.0.1
 coverage==5.5
 flake8==3.9.2
 freezegun==1.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ click==8.0.1
 coverage==5.5
 flake8==3.9.2
 freezegun==1.1.0
-more-itertools==8.7.0
+more-itertools==8.8.0
 pip-tools==6.1.0
 pytest-cov==2.12.0
 pytest-wholenodeid==0.2

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ markus==3.0.0
 raven==6.10.0
 
 # Development requirements
-Sphinx==3.5.4
+Sphinx==4.0.2
 bandit==1.7.0
 black==21.5b2
 click==8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -517,9 +517,9 @@ sphinx-rtd-theme==0.5.2 \
     --hash=sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a \
     --hash=sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f
     # via -r requirements.in
-sphinx==3.5.4 \
-    --hash=sha256:19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1 \
-    --hash=sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8
+sphinx==4.0.2 \
+    --hash=sha256:b5c2ae4120bf00c799ba9b3699bc895816d272d120080fbc967292f29b52b48c \
+    --hash=sha256:d1cb10bee9c4231f1700ec2e24a91be3f3a3aba066ea4ca9f3bbe47e59d5a1d4
     # via
     #   -r requirements.in
     #   sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -330,9 +330,9 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
     # via flake8
-more-itertools==8.7.0 \
-    --hash=sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced \
-    --hash=sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713
+more-itertools==8.8.0 \
+    --hash=sha256:2cf89ec599962f2ddc4d568a05defc40e0a587fbc10d5989713638864c36be4d \
+    --hash=sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a
     # via -r requirements.in
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,9 +47,9 @@ chardet==4.0.0 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
     # via requests
-click==7.1.2 \
-    --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a \
-    --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc
+click==8.0.1 \
+    --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a \
+    --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6
     # via
     #   -r requirements.in
     #   black


### PR DESCRIPTION
Update dependencies. This covers:

* Bump more-itertools from 8.7.0 to 8.8.0 (from PR #719)
* Bump sphinx from 3.5.4 to 4.0.2 (from PR #718)
* Bump click from 7.1.2 to 8.0.1 (from PR #717)
