### PR TITLE
Bump python from 3.9.5-slim to 3.9.6-slim in /docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-slim@sha256:8ffb28a4fca06fc0914dac67e801cf447df0225ea23ee1b42685de02f2555235
+FROM python:3.9.6-slim@sha256:2c018e29a8eada75e855d78641adda978a2c0a035fd928e281e1240144e8a337
 
 # Set up user and group
 ARG groupid=10001


### PR DESCRIPTION
Update dependencies. This covers:

* Bump python from 3.9.5-slim to 3.9.6-slim in /docker
