### PR TITLE
bug 1723964: fix sentry logging

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -25,7 +25,7 @@ from antenna.health_resource import (
 from antenna.heartbeat import HeartbeatManager
 from antenna.liblogging import setup_logging, log_config
 from antenna.libmarkus import setup_metrics
-from antenna.sentry import (
+from antenna.libsentry import (
     set_sentry_client,
     setup_sentry_logging,
     wsgi_capture_exceptions,


### PR DESCRIPTION
The sentry client was set to send all logged messages to Sentry. That's
not what we want--we only want errors. This fixes that.

While doing that, I renamed the module and fixed some variable names so
they fit our naming scheme better.