### PR TITLE
Fix the version check

### DIFF
--- a/systemtest/test_dockerflow.py
+++ b/systemtest/test_dockerflow.py
@@ -14,7 +14,12 @@ class TestDockerflow:
     def test_version(self, baseurl):
         resp = requests.get(baseurl + "__version__")
         assert resp.status_code == 200
-        assert resp.json() == {}
+        data = resp.json()
+        assert isinstance(data, dict)
+        data_keys = list(sorted(data.keys()))
+        # It's empty in the local dev environment, but has 4 keys in the server
+        # environment
+        assert data_keys == [] or data_keys == ["build", "commit", "source", "version"]
 
     def test_heartbeat(self, baseurl):
         resp = requests.get(baseurl + "__heartbeat__")


### PR DESCRIPTION
This fixes the version check in the dockerflow systemtest so it passes
with both a local dev environment (empty dict) and server environments
(dict with stuff in it).