### PR TITLE
Update release script

### DIFF
--- a/bin/release.py
+++ b/bin/release.py
@@ -2,7 +2,7 @@
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at https://mozilla.org/MPL/2.0/.
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 This script handles releases for this project.
@@ -13,7 +13,7 @@ both.
 This requires Python 3 to run.
 
 repo: https://github.com/willkg/socorro-release/
-sha: 926e826140d55515360205b28b4dd524997893a6
+sha: 522573cab99d7d7de2106853f3283d30bf88aaa9
 
 """
 
@@ -151,6 +151,20 @@ def make_tag(bug_number, remote_name, tag_name, commits_since_tag):
     input(f">>> Ready to push to remote {remote_name}? Ctrl-c to cancel")
     print(">>> Pushing...")
     subprocess.check_call(["git", "push", "--tags", remote_name, tag_name])
+
+    if bug_number:
+        # Show tag for adding to bug comment
+        print(f">>> Show tag... Copy and paste this into bug #{bug_number}.")
+        print(">>> %<-----------------------------------------------")
+        output = check_output(f"git show {tag_name}")
+        # Truncate the output at "diff --git"
+        output = output[: output.find("diff --git")].strip()
+        print(f"Tagged {tag_name}:")
+        print("")
+        print("```")
+        print(output)
+        print("```")
+        print(">>> %<-----------------------------------------------")
 
 
 def make_bug(


### PR DESCRIPTION
release now prints out the text to copy and paste into a bug comment
after making a tag.