### PR TITLE
Update pip-tools to 6.5.0 and remove pip restriction

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,7 @@ RUN apt-get update && \
 
 COPY --chown=app:app requirements.txt /app/
 
-# Install Socorro Python requirements using pip < 22 because pip 22
-# doesn't work with pip-tools. (2022-02-01)
-# https://github.com/jazzband/pip-tools/issues/1558
-RUN pip install -U 'pip<22' && \
+RUN pip install -U 'pip>=20' && \
     pip install --no-cache-dir -r requirements.txt && \
     pip check --disable-pip-version-check
 

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ coverage==6.2
 flake8==4.0.1
 freezegun==1.1.0
 more-itertools==8.12.0
-pip-tools==6.4.0
+pip-tools==6.5.0
 pytest-cov==3.0.0
 pytest==6.2.5
 requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -414,9 +414,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via pip-tools
-pip-tools==6.4.0 \
-    --hash=sha256:65553a15b1ba34be5e43889345062e38fb9b219ffa23b084ca0d4c4039b6f53b \
-    --hash=sha256:bb2c3272bc229b4a6d25230ebe255823aba1aa466a0d698c48ab7eb5ab7efdc9
+pip-tools==6.5.0 \
+    --hash=sha256:9cf69a020e3c208a7a1bcc78cbfd436dab323efc187919df6182eca98efbe3f2 \
+    --hash=sha256:d14ea4fc2c118db2a6af65a4345a8b9b355e792aedad6bf64dd3eb97c5fc5fee
     # via -r requirements.in
 platformdirs==2.4.1 \
     --hash=sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca \
@@ -594,11 +594,11 @@ wheel==0.37.1 \
     --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
     # via pip-tools
-zope.event==4.5.0 \
+zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330
     # via gevent
-zope.interface==5.4.0 \
+zope-interface==5.4.0 \
     --hash=sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192 \
     --hash=sha256:0b465ae0962d49c68aa9733ba92a001b2a0933c317780435f00be7ecb959c702 \
     --hash=sha256:0cba8477e300d64a11a9789ed40ee8932b59f9ee05f85276dbb4b59acee5dd09 \


### PR DESCRIPTION
pip-tools 6.5.0 fixes the issue it had with pip 22. This removes the restriction we put in place.