### PR TITLE
bug 1756223: change ci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
       - run:
           name: Lint
           command: |
+            touch .docker-build
             docker run local/antenna_deploy_base shell ./bin/run_lint.sh
 
   test:
@@ -101,6 +102,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+            touch .docker-build
             make test-ci
 
   push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,6 @@ jobs:
     environment:
       APP_NAME: "socorro_collector"
     steps:
-      - run:
-          name: Install essential packages
-          command: |
-            sudo apt-get install make
-
       - checkout
 
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-    working_directory: /
     environment:
       APP_NAME: "socorro_collector"
     steps:
@@ -21,12 +20,9 @@ jobs:
           command: |
             sudo apt-get install make
 
-      - checkout:
-          path: /antenna
-
+      - checkout
       - run:
           name: Create version.json
-          working_directory: /antenna
           command: |
             # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
@@ -34,10 +30,10 @@ jobs:
             "$CIRCLE_TAG" \
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
-            "$CIRCLE_BUILD_URL" > /antenna/version.json
+            "$CIRCLE_BUILD_URL" > version.json
 
       - store_artifacts:
-          path: /antenna/version.json
+          path: version.json
 
       - setup_remote_docker:
           version: 19.03.13
@@ -61,31 +57,26 @@ jobs:
 
       - run:
           name: Build Docker image
-          working_directory: /antenna
           command: |
             make build
 
       - run:
           name: Verify requirements.txt file
-          working_directory: /antenna
           command: |
             docker run local/antenna_deploy_base shell ./bin/run_verify_reqs.sh
 
       - run:
           name: Lint
-          working_directory: /antenna
           command: |
             docker run local/antenna_deploy_base shell ./bin/run_lint.sh
 
       - run:
           name: Run tests
-          working_directory: /antenna
           command: |
             make test-ci
 
       - run:
           name: Push to Dockerhub
-          working_directory: /antenna
           command: |
             function retry {
                 set +e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - checkout
       - run:
           name: Create version.json
+          # yamllint disable rule:line-length
           command: |
             # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
@@ -31,6 +32,7 @@ jobs:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
+          # yamllint enable rule:line-length
 
       - store_artifacts:
           path: version.json
@@ -41,12 +43,14 @@ jobs:
 
       - run:
           name: Login to Dockerhub
+          # yamllint disable rule:line-length
           command: |
             if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
               echo "Skipping Login to Dockerhub, credentials not available."
             else
               echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
             fi
+          # yamllint enable rule:line-length
 
       - run:
           name: Get info
@@ -78,6 +82,7 @@ jobs:
 
       - run:
           name: Push to Dockerhub
+          # yamllint disable rule:line-length
           command: |
             function retry {
                 set +e
@@ -116,6 +121,7 @@ jobs:
                 retry docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
               fi
             fi
+          # yamllint disable rule:line-length
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   build_test_push:
     docker:
-      - image: mozilla/cidockerbases:docker-latest
+      - image: cimg/base:2022.02
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -17,12 +17,9 @@ jobs:
       APP_NAME: "socorro_collector"
     steps:
       - run:
-          name: Host info
-          command: uname -v
-
-      - run:
           name: Install essential packages
-          command: apt-get install make
+          command: |
+            sudo apt-get install make
 
       - checkout:
           path: /antenna
@@ -57,6 +54,7 @@ jobs:
       - run:
           name: Get info
           command: |
+            uname -v
             docker info
             which docker-compose
             docker-compose --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 # DOCKER_PASS
 version: 2.1
 jobs:
-  build_test_push:
+  build:
     docker:
       - image: cimg/base:2022.02
         auth:
@@ -17,7 +17,8 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker:
+      - &setup_remote_docker
+        setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true
 
@@ -66,15 +67,54 @@ jobs:
           command: |
             docker run local/antenna_deploy_base shell ./bin/run_verify_reqs.sh
 
+  lint:
+    docker:
+      - image: cimg/base:2022.02
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    environment:
+      APP_NAME: "socorro_collector"
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
       - run:
           name: Lint
           command: |
             docker run local/antenna_deploy_base shell ./bin/run_lint.sh
 
+  test:
+    docker:
+      - image: cimg/base:2022.02
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    environment:
+      APP_NAME: "socorro_collector"
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
       - run:
           name: Run tests
           command: |
             make test-ci
+
+  push:
+    docker:
+      - image: cimg/base:2022.02
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    environment:
+      APP_NAME: "socorro_collector"
+    steps:
+      - checkout
+
+      - *setup_remote_docker
 
       - run:
           name: Push to Dockerhub
@@ -122,17 +162,20 @@ jobs:
 workflows:
   version: 2
 
-  # workflow jobs are _not_ run in tag builds by default
-  # we use filters to whitelist jobs that should be run for tags
-
-  # workflow jobs are run in _all_ branch builds by default
-  # we use filters to blacklist jobs that shouldn't be run for a branch
-
-  # see: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
-
   build_test_push:
     jobs:
-      - build_test_push:
+      - build
+      - lint:
+          requires:
+            - build
+      - test:
+          requires:
+            - build
+      - push:
+          requires:
+            - build
+            - lint
+            - test
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,19 @@ jobs:
             sudo apt-get install make
 
       - checkout
+
+      - setup_remote_docker:
+          version: 20.10.11
+          docker_layer_caching: true
+
+      - run:
+          name: Get info
+          command: |
+            uname -v
+            docker info
+            which docker-compose
+            docker-compose --version
+
       - run:
           name: Create version.json
           # yamllint disable rule:line-length
@@ -37,10 +50,6 @@ jobs:
       - store_artifacts:
           path: version.json
 
-      - setup_remote_docker:
-          version: 19.03.13
-          docker_layer_caching: true
-
       - run:
           name: Login to Dockerhub
           # yamllint disable rule:line-length
@@ -51,14 +60,6 @@ jobs:
               echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
             fi
           # yamllint enable rule:line-length
-
-      - run:
-          name: Get info
-          command: |
-            uname -v
-            docker info
-            which docker-compose
-            docker-compose --version
 
       - run:
           name: Build Docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
 
       - setup_remote_docker:
           version: 19.03.13
+          docker_layer_caching: true
 
       - run:
           name: Login to Dockerhub

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ my.env:
 
 .PHONY: build
 build: my.env  ## | Build docker images.
-	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID} deploy-base
-	${DC} build fakesentry
+	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID}
 	touch .docker-build
 
 .PHONY: setup


### PR DESCRIPTION
This switches from mozilla/cidockerbases which is deprecated to
cimg/base which is not.