### PR TITLE
bug 1756223: fix lint and test CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@
 version: 2.1
 jobs:
   build:
-    docker:
+    docker: &docker
       - image: cimg/base:2022.02
         auth:
           username: $DOCKER_USER
@@ -64,15 +64,13 @@ jobs:
 
       - run:
           name: Verify requirements.txt file
+          # yamllint disable rule:line-length
           command: |
-            docker run local/antenna_deploy_base shell ./bin/run_verify_reqs.sh
+            docker-compose run --no-deps deploy-base shell ./bin/run_verify_reqs.sh
+          # yamllint enable rule:line-length
 
   lint:
-    docker:
-      - image: cimg/base:2022.02
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    docker: *docker
     environment:
       APP_NAME: "socorro_collector"
     steps:
@@ -83,15 +81,11 @@ jobs:
       - run:
           name: Lint
           command: |
-            touch .docker-build
-            docker run local/antenna_deploy_base shell ./bin/run_lint.sh
+            make my.env
+            docker-compose run --no-deps deploy-base shell ./bin/run_lint.sh
 
   test:
-    docker:
-      - image: cimg/base:2022.02
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    docker: *docker
     environment:
       APP_NAME: "socorro_collector"
     steps:
@@ -102,15 +96,10 @@ jobs:
       - run:
           name: Run tests
           command: |
-            touch .docker-build
             make test-ci
 
   push:
-    docker:
-      - image: cimg/base:2022.02
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    docker: *docker
     environment:
       APP_NAME: "socorro_collector"
     steps:

--- a/Makefile
+++ b/Makefile
@@ -95,20 +95,20 @@ lintfix: my.env .docker-build  ## | Reformat code.
 .PHONY: test
 test: my.env .docker-build  ## | Run unit tests.
 	# Make sure services are started up
-	${DC} up -d localstack-s3
-	${DC} up -d localstack-sqs
-	${DC} up -d statsd
-	${DC} up -d fakesentry
+	${DC} up --detach localstack-s3
+	${DC} up --detach localstack-sqs
+	${DC} up --detach statsd
+	${DC} up --detach fakesentry
 	# Run tests
 	${DC} run --rm test shell ./bin/run_tests.sh
 
 .PHONY: test-ci
-test-ci: my.env .docker-build  ## | Run unit tests in CI.
+test-ci: my.env .docker-build  ## | Run unit tests in CI environment.
 	# Make sure services are started up
-	${DC} up -d localstack-s3
-	${DC} up -d localstack-sqs
-	${DC} up -d statsd
-	${DC} up -d fakesentry
+	${DC} up --detach --no-color localstack-s3
+	${DC} up --detach --no-color localstack-sqs
+	${DC} up --detach --no-color statsd
+	${DC} up --detach --no-color fakesentry
 	# Run tests in test-ci container
 	${DC} run --rm test-ci shell ./bin/run_tests.sh
 

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -24,8 +24,8 @@ PYTEST="$(which pytest)"
 PYTHON="$(which python)"
 
 # Wait for services to be ready
-urlwait "${CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL}" 10
-urlwait "${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL}" 10
+urlwait "${CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL}" 15
+urlwait "${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL}" 15
 
 # Run tests
 "${PYTEST}" $@


### PR DESCRIPTION
This undoes the "touch .docker-build" line. Docker image tags don't seem
to be available between jobs.

This also fixes the lint job to use the make rule so we're not
specifying it in two places.