### PR TITLE
bug 1756223: fix version.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,8 @@ jobs:
 
       - run:
           name: Verify requirements.txt file
-          # yamllint disable rule:line-length
           command: |
-            docker-compose run --no-deps deploy-base shell ./bin/run_verify_reqs.sh
-          # yamllint enable rule:line-length
+            docker-compose run --rm --no-deps ci shell ./bin/run_verify_reqs.sh
 
       - run:
           name: Save image
@@ -79,7 +77,6 @@ jobs:
           root: workspace
           paths:
             - antenna-deploy-base.tar.gz
-
 
   lint:
     docker: *docker
@@ -102,7 +99,7 @@ jobs:
           name: Lint
           command: |
             make my.env
-            docker-compose run --no-deps deploy-base shell ./bin/run_lint.sh
+            docker-compose run --rm --no-deps ci shell ./bin/run_lint.sh
 
   test:
     docker: *docker
@@ -124,7 +121,13 @@ jobs:
       - run:
           name: Run tests
           command: |
-            make test-ci
+            make my.env
+            docker-compose up --detach --no-color \
+                localstack-s3 \
+                localstack-sqs \
+                statsd \
+                fakesentry
+            docker-compose run --rm ci shell ./bin/run_tests.sh
 
   push:
     docker: *docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,6 @@ jobs:
             "$CIRCLE_BUILD_URL" > version.json
           # yamllint enable rule:line-length
 
-      - store_artifacts:
-          path: version.json
-
       - run:
           name: Login to Dockerhub
           # yamllint disable rule:line-length
@@ -69,6 +66,21 @@ jobs:
             docker-compose run --no-deps deploy-base shell ./bin/run_verify_reqs.sh
           # yamllint enable rule:line-length
 
+      - run:
+          name: Save image
+          # yamllint disable rule:line-length
+          command: |
+            mkdir -p workspace
+            docker save -o workspace/antenna-deploy-base.tar local/antenna_deploy_base:latest
+            gzip workspace/antenna-deploy-base.tar
+          # yamllint enable rule:line-length
+
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - antenna-deploy-base.tar.gz
+
+
   lint:
     docker: *docker
     environment:
@@ -77,6 +89,14 @@ jobs:
       - checkout
 
       - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/antenna-deploy-base.tar.gz
 
       - run:
           name: Lint
@@ -93,6 +113,14 @@ jobs:
 
       - *setup_remote_docker
 
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/antenna-deploy-base.tar.gz
+
       - run:
           name: Run tests
           command: |
@@ -106,6 +134,14 @@ jobs:
       - checkout
 
       - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/antenna-deploy-base.tar.gz
 
       - run:
           name: Push to Dockerhub

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ my.env:
 
 .PHONY: build
 build: my.env  ## | Build docker images.
-	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID}
+	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID} deploy-base
+	${DC} build fakesentry
 	touch .docker-build
 
 .PHONY: setup

--- a/Makefile
+++ b/Makefile
@@ -103,16 +103,6 @@ test: my.env .docker-build  ## | Run unit tests.
 	# Run tests
 	${DC} run --rm test shell ./bin/run_tests.sh
 
-.PHONY: test-ci
-test-ci: my.env .docker-build  ## | Run unit tests in CI environment.
-	# Make sure services are started up
-	${DC} up --detach --no-color localstack-s3
-	${DC} up --detach --no-color localstack-sqs
-	${DC} up --detach --no-color statsd
-	${DC} up --detach --no-color fakesentry
-	# Run tests in test-ci container
-	${DC} run --rm test-ci shell ./bin/run_tests.sh
-
 .PHONY: testshell
 testshell: my.env .docker-build  ## | Open a shell in the test container.
 	${DC} run --rm test shell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
     volumes:
       - .:/app
 
-  # Same as test container, but doesn't volume mount .
-  test-ci:
+  # Container that we use in CI--it can't volume mount things
+  ci:
     image: local/antenna_deploy_base
     env_file:
       - docker/config/local_dev.env
@@ -51,7 +51,7 @@ services:
       - localstack-s3
       - statsd
 
-  # Web container is a prod-like fully-functioning Antenna container.
+  # Web container is a prod-like fully-functioning Antenna container
   web:
     extends:
       service: base


### PR DESCRIPTION
The version.json file isn't in the image that got pushed to dockerhub.
This reworks things so that the build job saves the image to the
workspace and that's used for subsequent jobs.