### PR TITLE
bug 1757039: update to localstack 0.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,7 @@ jobs:
           command: |
             make my.env
             docker-compose up --detach --no-color \
-                localstack-s3 \
-                localstack-sqs \
+                localstack \
                 statsd \
                 fakesentry
             docker-compose run --rm ci shell ./bin/run_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,7 @@ lintfix: my.env .docker-build  ## | Reformat code.
 .PHONY: test
 test: my.env .docker-build  ## | Run unit tests.
 	# Make sure services are started up
-	${DC} up --detach localstack-s3
-	${DC} up --detach localstack-sqs
+	${DC} up --detach localstack
 	${DC} up --detach statsd
 	${DC} up --detach fakesentry
 	# Run tests

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ production, see docs_.
 
    Anytime you want to update the containers, you can run ``make build``.
 
-4. Set up local Pub/Sub and S3 services:
+4. Set up local SQS and S3 services:
 
    .. code-block:: shell
 
@@ -66,9 +66,8 @@ production, see docs_.
       You should see a lot of output. It'll start out with something like this::
 
          /usr/bin/docker-compose up web
-         antenna_localstack-sqs_1 is up-to-date
          antenna_statsd_1 is up-to-date
-         antenna_localstack-s3_1 is up-to-date
+         antenna_localstack_1 is up-to-date
          Starting antenna_web_1 ... done
          Attaching to antenna_web_1
          web_1    | + PORT=8000
@@ -100,12 +99,12 @@ production, see docs_.
          web_1    | 2021-08-04 19:25:30,672 INFO - antenna - antenna.app - CRASHMOVER_CRASHSTORAGE_ACCESS_KEY=foo
          web_1    | 2021-08-04 19:25:30,672 INFO - antenna - antenna.app - CRASHMOVER_CRASHSTORAGE_SECRET_ACCESS_KEY=*****
          web_1    | 2021-08-04 19:25:30,672 INFO - antenna - antenna.app - CRASHMOVER_CRASHSTORAGE_REGION=us-east-1
-         web_1    | 2021-08-04 19:25:30,672 INFO - antenna - antenna.app - CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:4572
+         web_1    | 2021-08-04 19:25:30,672 INFO - antenna - antenna.app - CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL=http://localstack:4566
          web_1    | 2021-08-04 19:25:30,672 INFO - antenna - antenna.app - CRASHMOVER_CRASHSTORAGE_BUCKET_NAME=antennabucket
          web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - CRASHMOVER_CRASHPUBLISH_ACCESS_KEY=foo
          web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - CRASHMOVER_CRASHPUBLISH_SECRET_ACCESS_KEY=*****
          web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - CRASHMOVER_CRASHPUBLISH_REGION=us-east-1
-         web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL=http://localstack-sqs:4576
+         web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL=http://localstack:4566
          web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - CRASHMOVER_CRASHPUBLISH_QUEUE_NAME=local_dev_socorro_standard
          web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - BREAKPAD_DUMP_FIELD=upload_file_minidump
          web_1    | 2021-08-04 19:25:30,673 INFO - antenna - antenna.app - BREAKPAD_THROTTLER_RULES=antenna.throttler.MOZILLA_RULES
@@ -126,7 +125,7 @@ production, see docs_.
 
          $ docker-compose ps
 
-      You should see containers with names ``web``, ``statsd`` and ``localstack-s3``.
+      You should see containers with names ``web``, ``statsd`` and ``localstack``.
 
    3. Send in a crash report:
 
@@ -152,17 +151,14 @@ production, see docs_.
          web_1      | [2016-11-07 15:48:45 +0000] [INFO] antenna.breakpad_resource: a448814e-16dd-45fb-b7dd-b0b522161010 saved
 
 
-   4. See the data in localstack-s3:
+   4. See the data in localstack:
 
-      The ``localstack-s3`` container stores data in memory and the data
-      doesn't persist between container restarts.
+      The ``localstack`` container stores data in memory and the data doesn't
+      persist between container restarts.
 
-      You can use the aws-cli to access it. For example::
+      You can use the ``bin/s3_cli.py`` to access it::
 
-        AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=foo \
-            aws --endpoint-url=http://localhost:5000 \
-                --region=us-east-1 \
-                s3 ls s3://antennabucket/
+        docker-compose run --rm web shell python bin/s3_cli.py list_buckets
 
       If you do this a lot, turn it into a shell script.
 

--- a/antenna/util.py
+++ b/antenna/util.py
@@ -69,13 +69,17 @@ def get_version_info(basedir):
     :returns: version info as a dict or an empty dict
 
     """
-    try:
-        path = Path(basedir) / "version.json"
-        with open(str(path)) as fp:
-            commit_info = json.loads(fp.read().strip())
-    except OSError as exc:
-        logger.info(f"Exception thrown when retrieving version.json: {exc}")
+    path = Path(basedir) / "version.json"
+    if not path.exists():
         commit_info = {}
+
+    else:
+        try:
+            with open(str(path)) as fp:
+                commit_info = json.loads(fp.read().strip())
+        except OSError as exc:
+            logger.info(f"Exception thrown when retrieving version.json: {exc}")
+            commit_info = {}
     return commit_info
 
 

--- a/bin/run_setup.sh
+++ b/bin/run_setup.sh
@@ -12,11 +12,9 @@
 
 set -euo pipefail
 
-# Wait for services to be ready
+# Wait for services to be ready (both have the same endpoint url)
 echo "Waiting for ${CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL} ..."
-urlwait "${CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL}" 10
-echo "Waiting for ${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL} ..."
-urlwait "${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL}" 10
+urlwait "${CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL}" 15
 
 echo "Delete and create S3 bucket..."
 python ./bin/s3_cli.py delete "${CRASHMOVER_CRASHSTORAGE_BUCKET_NAME}"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -23,8 +23,7 @@ export PYTHONPATH=/app/:${PYTHONPATH:-}
 PYTEST="$(which pytest)"
 PYTHON="$(which python)"
 
-# Wait for services to be ready
-urlwait "${CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL}" 15
+# Wait for services to be ready (both have the same endpoint url)
 urlwait "${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL}" 15
 
 # Run tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,7 @@ services:
       - docker/config/test.env
     links:
       - fakesentry
-      - localstack-sqs
-      - localstack-s3
+      - localstack
       - statsd
     volumes:
       - .:/app
@@ -47,8 +46,7 @@ services:
       - docker/config/test.env
     links:
       - fakesentry
-      - localstack-sqs
-      - localstack-s3
+      - localstack
       - statsd
 
   # Web container is a prod-like fully-functioning Antenna container
@@ -63,33 +61,20 @@ services:
     command: web
     links:
       - fakesentry
-      - localstack-s3
-      - localstack-sqs
+      - localstack
       - statsd
 
   # https://hub.docker.com/r/localstack/localstack/
-  # localstack running a fake S3
-  localstack-s3:
-    image: localstack/localstack:0.10.5
+  # localstack running a fake S3 and SQS
+  localstack:
+    image: localstack/localstack:0.14.0
     environment:
-      - SERVICES=s3:4572
+      - SERVICES=s3,sqs
       - DEFAULT_REGION=us-east-1
-      - HOSTNAME=localstack-s3
-      - HOSTNAME_EXTERNAL=localstack-s3
+      - HOSTNAME=localstack
+      - HOSTNAME_EXTERNAL=localstack
     ports:
-      - "4572:4572"
-
-  # https://hub.docker.com/r/localstack/localstack/
-  # localstack running a fake sqs
-  localstack-sqs:
-    image: localstack/localstack:0.10.5
-    environment:
-      - SERVICES=sqs:4576
-      - DEFAULT_REGION=us-east-1
-      - HOSTNAME=localstack-sqs
-      - HOSTNAME_EXTERNAL=localstack-sqs
-    ports:
-      - "4576:4576"
+      - "4566:4566"
 
   # https://hub.docker.com/r/kamon/grafana_graphite/
   # username: admin, password: admin

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -1,4 +1,4 @@
-# prod-like Antenna environment with localstack-s3.
+# prod-like Antenna environment with localstack.
 #
 # See https://antenna.readthedocs.io/ for documentation.
 
@@ -17,14 +17,14 @@ CRASHMOVER_CRASHSTORAGE_CLASS=antenna.ext.s3.crashstorage.S3CrashStorage
 CRASHMOVER_CRASHPUBLISH_CLASS=antenna.ext.sqs.crashpublish.SQSCrashPublish
 
 # S3 settings
-CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:4572
+CRASHMOVER_CRASHSTORAGE_ENDPOINT_URL=http://localstack:4566
 CRASHMOVER_CRASHSTORAGE_REGION=us-east-1
 CRASHMOVER_CRASHSTORAGE_ACCESS_KEY=foo
 CRASHMOVER_CRASHSTORAGE_SECRET_ACCESS_KEY=foo
 CRASHMOVER_CRASHSTORAGE_BUCKET_NAME=antennabucket
 
 # SQS settings
-CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL=http://localstack-sqs:4576
+CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL=http://localstack:4566
 CRASHMOVER_CRASHPUBLISH_REGION=us-east-1
 CRASHMOVER_CRASHPUBLISH_ACCESS_KEY=foo
 CRASHMOVER_CRASHPUBLISH_SECRET_ACCESS_KEY=foo


### PR DESCRIPTION
Updating to localstack 0.14.0 lets us simplify our local dev environment
a little. We only have to run a single localstack service which handles
both SQS and S3.

While doing this, I fixed an issue with retrieving version.json in the
local dev environment and I updated the README.