### PR TITLE
bug 1748256: handle when extra is not a dict value

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -206,6 +206,9 @@ class BreakpadSubmitterResource:
                     # of "malformed JSON" situations.
                     raise MalformedCrashReport("bad_json")
 
+                if not isinstance(raw_crash, dict):
+                    raise MalformedCrashReport("bad_json")
+
             elif fs_item.type and (
                 fs_item.type.startswith("application/octet-stream")
                 or isinstance(fs_item.value, bytes)


### PR DESCRIPTION
extra should be a JSON-encoded dict of key/value pairs. If it's not a
dict, then that's malformed and we should treat it as such.