### PR TITLE
bug 1669981: remove caplogpp

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -4,7 +4,6 @@
 
 import contextlib
 from pathlib import Path
-import logging
 import sys
 from unittest import mock
 
@@ -176,18 +175,3 @@ def randommock():
             yield
 
     return _randommock
-
-
-@pytest.fixture
-def caplogpp(caplog):
-    """caplogpp fixes propagation logger values and returns caplog fixture"""
-    changed_loggers = []
-    for logger in logging.Logger.manager.loggerDict.values():
-        if getattr(logger, "propagate", True) is False:
-            logger.propagate = True
-            changed_loggers.append(logger)
-
-    yield caplog
-
-    for logger in changed_loggers:
-        logger.propagate = False

--- a/tests/unittest/test_crashmover.py
+++ b/tests/unittest/test_crashmover.py
@@ -79,7 +79,7 @@ class TestCrashMover:
         # No more coroutines and no more queue
         check_health(crashmover_pool_size=0, crashmover_queue_size=0)
 
-    def test_retry_storage(self, client, caplogpp):
+    def test_retry_storage(self, client, caplog):
         crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         raw_crash = {
             "uuid": crash_id,
@@ -112,7 +112,7 @@ class TestCrashMover:
         # We're using BadCrashStorage so the crashmover should retry 20
         # times logging a message each time and then give up
         records = [
-            rec[2] for rec in caplogpp.record_tuples if rec[0] == "antenna.crashmover"
+            rec[2] for rec in caplog.record_tuples if rec[0] == "antenna.crashmover"
         ]
         assert records == [
             f"Exception when processing queue ({crash_id}), state: save; error 1/20",
@@ -138,7 +138,7 @@ class TestCrashMover:
             f"{crash_id}: too many errors trying to save; dropped",
         ]
 
-    def test_retry_publish(self, client, caplogpp):
+    def test_retry_publish(self, client, caplog):
         crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         raw_crash = {
             "uuid": crash_id,
@@ -171,7 +171,7 @@ class TestCrashMover:
         # We're using BadCrashStorage so the crashmover should retry 20
         # times logging a message each time and then give up
         records = [
-            rec[2] for rec in caplogpp.record_tuples if rec[0] == "antenna.crashmover"
+            rec[2] for rec in caplog.record_tuples if rec[0] == "antenna.crashmover"
         ]
 
         assert records == [

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -187,7 +187,7 @@ class TestS3CrashStorageIntegration:
         # Assert we did the entire s3 conversation
         assert s3mock.remaining_conversation() == []
 
-    def test_retrying(self, client, s3mock, caplogpp, mock_generate_test_filepath):
+    def test_retrying(self, client, s3mock, caplog, mock_generate_test_filepath):
         # .verify_write_to_bucket() writes to the bucket to verify Antenna can
         # write to it and the configuration is correct
         s3mock.add_step(
@@ -266,9 +266,7 @@ class TestS3CrashStorageIntegration:
 
         # Verify the retry decorator logged something
         records = [
-            rec
-            for rec in caplogpp.record_tuples
-            if rec[0] == "antenna.ext.s3.connection"
+            rec for rec in caplog.record_tuples if rec[0] == "antenna.ext.s3.connection"
         ]
         assert records == [
             (

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -266,9 +266,9 @@ class Testmozilla_rules:
             ("testproduct", (REJECT, "unsupported_product", 100)),
         ],
     )
-    def test_productname_reject(self, caplogpp, productname, expected):
+    def test_productname_reject(self, caplog, productname, expected):
         """Verify productname rule blocks unsupported products"""
-        with caplogpp.at_level(logging.INFO, logger="antenna"):
+        with caplog.at_level(logging.INFO, logger="antenna"):
             # Need a throttler with the default configuration which includes supported
             # products
             throttler = Throttler(ConfigManager.from_dict({}))
@@ -276,7 +276,7 @@ class Testmozilla_rules:
             if productname is not None:
                 raw_crash["ProductName"] = productname
             assert throttler.throttle(raw_crash) == expected
-            assert caplogpp.record_tuples == [
+            assert caplog.record_tuples == [
                 (
                     "antenna.throttler",
                     logging.INFO,
@@ -284,27 +284,27 @@ class Testmozilla_rules:
                 )
             ]
 
-    def test_productname_none_reject(self, caplogpp):
+    def test_productname_none_reject(self, caplog):
         """Verify productname rule blocks None value"""
-        with caplogpp.at_level(logging.INFO, logger="antenna"):
+        with caplog.at_level(logging.INFO, logger="antenna"):
             # Need a throttler with the default configuration which includes supported
             # products
             throttler = Throttler(ConfigManager.from_dict({}))
             raw_crash = {"ProductName": None}
             assert throttler.throttle(raw_crash) == (REJECT, "unsupported_product", 100)
-            assert caplogpp.record_tuples == [
+            assert caplog.record_tuples == [
                 ("antenna.throttler", logging.INFO, "ProductName rejected: 'None'")
             ]
 
-    def test_productname_fakeaccept(self, caplogpp):
+    def test_productname_fakeaccept(self, caplog):
         # This product isn't in the list and it's B2G which is the special case
-        with caplogpp.at_level(logging.INFO, logger="antenna"):
+        with caplog.at_level(logging.INFO, logger="antenna"):
             # Need a throttler with the default configuration which includes supported
             # products
             throttler = Throttler(ConfigManager.from_dict({}))
             raw_crash = {"ProductName": "b2g"}
             assert throttler.throttle(raw_crash) == (FAKEACCEPT, "b2g", 100)
-            assert caplogpp.record_tuples == [
+            assert caplog.record_tuples == [
                 ("antenna.throttler", logging.INFO, "ProductName B2G: fake accept")
             ]
 


### PR DESCRIPTION
A while back, I redid how logging was set up in Antenna which removed
the need for caplogpp, but I never actually removed caplogpp. This
removes it.