### PR TITLE
bug 1562641: rework payload handling

### DIFF
--- a/antenna/util.py
+++ b/antenna/util.py
@@ -198,8 +198,17 @@ def get_date_from_crash_id(crash_id, as_datetime=False):
 ALPHA_NUMERIC_UNDERSCORE = string.ascii_letters + string.digits + "_"
 
 
-def sanitize_dump_name(val):
-    """Sanitize a dump name."""
+def sanitize_key_name(val):
+    """Sanitize a key name.
+
+    :param val: the value to sanitize
+
+    :returns: the value as a sanitized str
+
+    """
+    if isinstance(val, bytes):
+        val = val.decode("utf-8")
+
     # Dump names can only contain ASCII alpha-numeric characters and
     # underscores
     val = "".join(v for v in val if v in ALPHA_NUMERIC_UNDERSCORE)

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -117,25 +117,6 @@ class TestBreakpadSubmitterResource:
         }
         assert bsp.extract_payload(req) == (expected_raw_crash, expected_dumps)
 
-    def test_extract_payload_bad_boundary(self, request_generator):
-        crashmover = FakeCrashMover()
-        data, headers = multipart_encode(
-            {
-                "ProductName": "Firefox",
-                "Version": "1.0",
-                "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
-            },
-            # This is a junk non-ascii boundary that causes FieldStorage to raise a
-            # ValueError
-            boundary="\xc3\xbf.",
-        )
-        req = request_generator(
-            method="POST", path="/submit", headers=headers, body=data
-        )
-        bsp = BreakpadSubmitterResource(config=self.empty_config, crashmover=crashmover)
-        with pytest.raises(MalformedCrashReport, match="malformed_boundary"):
-            bsp.extract_payload(req)
-
     def test_extract_payload_bad_content_type(self, request_generator):
         crashmover = FakeCrashMover()
         headers = {"Content-Type": "application/json"}

--- a/tests/unittest/test_util.py
+++ b/tests/unittest/test_util.py
@@ -15,7 +15,7 @@ from antenna.util import (
     get_version_info,
     isoformat_to_time,
     retry,
-    sanitize_dump_name,
+    sanitize_key_name,
     utc_now,
     validate_crash_id,
 )
@@ -117,8 +117,8 @@ def test_validate_crash_id(data, strict, expected):
         ("upload_file_m\xef\xbf\xbdnidump", "upload_file_mnidump"),
     ],
 )
-def test_sanitize_dump_name(data, expected):
-    assert sanitize_dump_name(data) == expected
+def test_sanitize_key_name(data, expected):
+    assert sanitize_key_name(data) == expected
 
 
 def make_fake_sleep():


### PR DESCRIPTION
Python 3.11 is deprecating the cgi module which has the FieldStorage class that we were using for parsing multipart HTTP payloads. Falcon 3.0 added handling code for multipart payloads. This switches to using that.

When this deploys to stage, we're going to want to verify it's working and that all the annotations are there. We should spend some time comparing crash reports on stage with those on prod. They should be the same (modulo submitted_timestamp and a few other fields).