### PR TITLE
bug 1757748: fix jobs in workflow to run on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,13 +193,22 @@ workflows:
 
   build_test_push:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - lint:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
       - test:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
       - push:
           requires:
             - build


### PR DESCRIPTION
This fixes the jobs in the workflow to run on tags. CircleCI doesn't
run jobs on tags by default, so we have to explicitly tell it to.