### PR TITLE
Updates 20220302

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ coverage==6.2
 flake8==4.0.1
 freezegun==1.1.0
 more-itertools==8.12.0
-pip-tools==6.5.0
+pip-tools==6.5.1
 pytest-cov==3.0.0
 pytest==6.2.5
 requests==2.27.1

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Production requirements
 boto3==1.20.26
-botocore==1.23.47
+botocore==1.23.54
 datadog==0.43.0
 dockerflow==2022.1.0
 everett==3.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ sentry-sdk==1.5.4
 
 # Development requirements
 Sphinx==4.4.0
-bandit==1.7.2
+bandit==1.7.3
 black==22.1.0
 click==8.0.3
 coverage==6.2

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ gevent==21.12.0
 gunicorn==20.1.0
 isodate==0.6.1
 markus==4.0.0
-sentry-sdk==1.5.4
+sentry-sdk==1.5.6
 
 # Development requirements
 Sphinx==4.4.0

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ freezegun==1.1.0
 more-itertools==8.12.0
 pip-tools==6.5.1
 pytest-cov==3.0.0
-pytest==6.2.5
+pytest==7.0.1
 requests==2.27.1
 sphinx-rtd-theme==1.0.0
 urlwait==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
     # via sphinx
-bandit==1.7.2 \
-    --hash=sha256:6d11adea0214a43813887bfe71a377b5a9955e4c826c8ffd341b494e3ab25260 \
-    --hash=sha256:e20402cadfd126d85b68ed4c8862959663c8c372dbbb1fca8f8e2c9f55a067ec
+bandit==1.7.3 \
+    --hash=sha256:3ce9b4e6a4f7f41aa966c9543e635dd35e52a793a47e746f0c55c7ecfc69d7e8 \
+    --hash=sha256:58772ca951bf1129dda8a280d351547de832720bf7b5c29fac3103927980b8a6
     # via -r requirements.in
 black==22.1.0 \
     --hash=sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -417,9 +417,9 @@ pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
     # via packaging
-pytest==6.2.5 \
-    --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89 \
-    --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134
+pytest==7.0.1 \
+    --hash=sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db \
+    --hash=sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -539,10 +539,6 @@ stevedore==3.5.0 \
     --hash=sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c \
     --hash=sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335
     # via bandit
-toml==0.10.2 \
-    --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
-    --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
-    # via pytest
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
@@ -550,6 +546,7 @@ tomli==2.0.1 \
     #   black
     #   coverage
     #   pep517
+    #   pytest
 urllib3==1.26.8 \
     --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
     --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c

--- a/requirements.txt
+++ b/requirements.txt
@@ -483,9 +483,9 @@ s3transfer==0.5.2 \
     --hash=sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971 \
     --hash=sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed
     # via boto3
-sentry-sdk==1.5.4 \
-    --hash=sha256:4fc7960a82c95d906a0514cf4d9aacba1743eb9863a5b7c2a01c525a7d9b21e6 \
-    --hash=sha256:f7e54567937ebcbe938c4df1075ec891587faeb7c74184b88cf2894e47c86116
+sentry-sdk==1.5.6 \
+    --hash=sha256:1ab34e3851a34aeb3d1af1a0f77cec73978c4e9698e5210d050e4932953cb241 \
+    --hash=sha256:ac2a50128409d57655279817aedcb7800cace1f76b266f3dd62055d5afd6e098
     # via -r requirements.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -385,9 +385,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via pip-tools
-pip-tools==6.5.0 \
-    --hash=sha256:9cf69a020e3c208a7a1bcc78cbfd436dab323efc187919df6182eca98efbe3f2 \
-    --hash=sha256:d14ea4fc2c118db2a6af65a4345a8b9b355e792aedad6bf64dd3eb97c5fc5fee
+pip-tools==6.5.1 \
+    --hash=sha256:80f1cfc7156e4a4465b1a46a6bb3599587909537db1a149cf3a6b73eed979ee4 \
+    --hash=sha256:80f562aa699fc76a424539697e0bef41e490a050e57a6a21468531981a9d419e
     # via -r requirements.in
 platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,9 +49,9 @@ boto3==1.20.26 \
     --hash=sha256:9c13f5c8fadf29088fac5feab849399169b6e8438c3b9a2310abdb7e5013ab65 \
     --hash=sha256:e8787a7f7c212d5b469dd8b998560c1b8e63badad5ceefb8331f4580386af044
     # via -r requirements.in
-botocore==1.23.47 \
-    --hash=sha256:82da38e309bd6fd6303394e6e9d1ea50626746f2911e3fec996f9046c5d85085 \
-    --hash=sha256:a89b1be0a7f235533d8279d90b0b15dc2130d0552a9f7654ba302b564ab5688a
+botocore==1.23.54 \
+    --hash=sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e \
+    --hash=sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb
     # via
     #   -r requirements.in
     #   boto3


### PR DESCRIPTION
Update dependencies. This covers:

* Bump pytest from 6.2.5 to 7.0.1 (from PR #798)
* Bump sentry-sdk from 1.5.4 to 1.5.6 (from PR #797)
* Bump pip-tools from 6.5.0 to 6.5.1 (from PR #796)
* Bump bandit from 1.7.2 to 1.7.3 (from PR #795)
* Bump botocore from 1.23.47 to 1.23.54 (from PR #794)
