### PR TITLE
bug 1757786: restrict annotation handling and add debugging

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -213,10 +213,15 @@ class BreakpadSubmitterResource:
                     dump_name = sanitize_key_name(part.name)
                     dumps[dump_name] = part.stream.read()
 
-                else:
+                elif part.content_type.startswith("text/plain"):
                     # This isn't a dump, so it's a key/val pair, so we add that as a string.
                     has_kvpairs = True
                     raw_crash[part.name] = part.get_text()
+                else:
+                    # bug 1757786: debugging code
+                    logging.error(
+                        f"unknown content type: {part.name} {part.content_type}"
+                    )
 
         except MultipartParseError as mpe:
             logger.error(f"extract payload exception: {mpe.description}")


### PR DESCRIPTION
This restricts payload extraction to treating only parts of type
text/plain as annotations. It also adds some debugging code to send
errors to sentry when we see parts that aren't test/plain or
application/octet-stream.

I think this will alleviate the bug but also make other situations more
obvious.