### PR TITLE
bug 1757801: increase max_body_part_buffer_size

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -77,7 +77,10 @@ class BreakpadSubmitterResource:
         self.throttler = Throttler(config.with_namespace("throttler"))
 
         self._multipart_parse_options = MultipartParseOptions()
+        # Setting this to 0 means "infinity"
         self._multipart_parse_options.max_body_part_count = 0
+        # We set this to 20mb semi-arbitrarily; we can increase it as we need to
+        self._multipart_parse_options.max_body_part_buffer_size = 20 * 1024 * 1024
 
     def get_components(self):
         """Return map of namespace -> component for traversing component tree."""


### PR DESCRIPTION
The default max_body_part_buffer_size is 1mb which probably isn't large
enough for minidumps. This increases it to a semi-arbitrary 20mb.