### PR TITLE
bug 1757854: make systemtests easier to use for debugging

### DIFF
--- a/bin/run_lint.sh
+++ b/bin/run_lint.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-BLACKARGS=("--line-length=88" "--target-version=py37" antenna bin testlib tests)
+BLACKARGS=("--line-length=88" "--target-version=py37" antenna bin testlib tests systemtest)
 
 if [[ "${1:-}" == "--fix" ]]; then
     echo ">>> black fix"
@@ -20,7 +20,7 @@ if [[ "${1:-}" == "--fix" ]]; then
 
 else
     echo ">>> flake8"
-    flake8 --statistics antenna tests/unittest/
+    flake8 --statistics antenna tests/unittest/ systemtest/
 
     echo ">>> black"
     black --check "${BLACKARGS[@]}"

--- a/systemtest/conftest.py
+++ b/systemtest/conftest.py
@@ -107,7 +107,9 @@ def s3conn(config):
     """Generate and returns an S3 connection using env config."""
     return S3Connection(
         access_key=config("crashmover_crashstorage_access_key", default=""),
-        secret_access_key=config("crashmover_crashstorage_secret_access_key", default=""),
+        secret_access_key=config(
+            "crashmover_crashstorage_secret_access_key", default=""
+        ),
         endpoint_url=config("crashmover_crashstorage_endpoint_url", default=""),
         region=config("crashmover_crashstorage_region", default="us-west-2"),
         bucket=config("crashmover_crashstorage_bucket_name"),
@@ -148,7 +150,9 @@ class SQSHelper:
         crashids = []
         while True:
             resp = self.client.receive_message(
-                QueueUrl=queue_url, WaitTimeSeconds=0, VisibilityTimeout=2,
+                QueueUrl=queue_url,
+                WaitTimeSeconds=0,
+                VisibilityTimeout=2,
             )
             msgs = resp.get("Messages", [])
             if not msgs:
@@ -170,7 +174,9 @@ def sqshelper(config):
     """Generate and returns a PubSub helper using env config."""
     return SQSHelper(
         access_key=config("crashmover_crashpublish_access_key", default=""),
-        secret_access_key=config("crashmover_crashpublish_secret_access_key", default=""),
+        secret_access_key=config(
+            "crashmover_crashpublish_secret_access_key", default=""
+        ),
         endpoint_url=config("crashmover_crashpublish_endpoint_url", default=""),
         region=config("crashmover_crashpublish_region", default=""),
         queue_name=config("crashmover_crashpublish_queue_name", default=""),

--- a/systemtest/test_post_crash.py
+++ b/systemtest/test_post_crash.py
@@ -33,7 +33,9 @@ SLEEP_TIME = 5
 
 
 class TestPostCrash:
-    def test_regular(self, posturl, s3conn, sqshelper, crash_generator, crash_verifier, postcheck):
+    def test_regular(
+        self, posturl, s3conn, sqshelper, crash_generator, crash_verifier, postcheck
+    ):
         """Post a valid crash and verify the contents made it to S3."""
         if not postcheck:
             pytest.skip("no access to S3")
@@ -53,7 +55,9 @@ class TestPostCrash:
         crash_verifier.verify_stored_data(crash_id, raw_crash, dumps, s3conn)
         crash_verifier.verify_published_data(crash_id, sqshelper)
 
-    def test_compressed_crash(self, posturl, s3conn, sqshelper, crash_generator, crash_verifier, postcheck):
+    def test_compressed_crash(
+        self, posturl, s3conn, sqshelper, crash_generator, crash_verifier, postcheck
+    ):
         """Post a compressed crash and verify contents made it to S3."""
         if not postcheck:
             pytest.skip("no access to S3")


### PR DESCRIPTION
This moves some bits around in the systemtest code to make it easier to
use for debugging crash report submission bugs.