### PR TITLE
bug 1756223: have gzip do a fast compression pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           command: |
             mkdir -p workspace
             docker save -o workspace/antenna-deploy-base.tar local/antenna_deploy_base:latest
-            gzip workspace/antenna-deploy-base.tar
+            gzip --fast workspace/antenna-deploy-base.tar
           # yamllint enable rule:line-length
 
       - persist_to_workspace:


### PR DESCRIPTION
The difference in sizes isn't very much, but the difference in the time
it takes to compress the image is 10-15s which is a chunk of build time.