### PR TITLE
bug 1760187: improve s3_cli and extract_payload error messages

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -209,7 +209,7 @@ class BreakpadSubmitterResource:
                     if not isinstance(raw_crash, dict):
                         raise MalformedCrashReport("invalid_json_value")
 
-                elif part.content_type.startswith("text/plain"):
+                elif part.content_type.startswith("text/plain") and not part.filename:
                     # This isn't a dump, so it's a key/val pair, so we add that as a string.
                     has_kvpairs = True
                     try:
@@ -218,8 +218,7 @@ class BreakpadSubmitterResource:
                         logger.error(
                             f"extract payload text part exception: {mpe.description}"
                         )
-                        msg = "invalid_annotation_value"
-                        raise MalformedCrashReport(msg) from mpe
+                        raise MalformedCrashReport("invalid_annotation_value") from mpe
 
                 else:
                     if part.content_type != "application/octet-stream":


### PR DESCRIPTION
This improves the s3_cli giving it the ability to download files.

This improves the error messages from extract_payload so it's easier to identify and fix crash reporter client errors.

Previously, we had:

* malformed_no_content_type
* malformed_wrong_content_type
* malformed_no_boundary
* malformed_no_content_length
* malformed_bad_gzip
* malformed_bad_json
* malformed_no_annotations
* malformed_has_json_and_kv

Now, we've got:

* malformed_no_content_type
* malformed_wrong_content_type
* malformed_no_boundary
* malformed_no_content_length
* malformed_bad_gzip
* malformed_invalid_json
* malformed_invalid_json_value
* malformed_invalid_annotation_value
* malformed_invalid_payload_structure
* malformed_no_annotations
* malformed_has_json_and_kv

That makes it easier to differentiate between "no annotations" because there are malformed parts or "no annotations" because there weren't any annotations. It also clarifies "invalid json" (there was a decoding error) from "invalid json value" (the value isn't a python dict).