### PR TITLE
bug 1762055: update kent to 0.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,12 @@ jobs:
             docker load -i workspace/antenna-deploy-base.tar.gz
 
       - run:
+          name: Build Docker image
+          command: |
+            make build
+            docker-compose images
+
+      - run:
           name: Run tests
           command: |
             make my.env

--- a/docker/Dockerfile.fakesentry
+++ b/docker/Dockerfile.fakesentry
@@ -1,4 +1,4 @@
-FROM python:3.10.1-alpine3.15@sha256:9c51896b90ca7175dc8aafcf8408207f404f247728228fb857add24bb26a18fa
+FROM python:3.10.4-alpine3.15@sha256:e92fae16dec802fc6dc650dae463548d314868c97a49e2f650ef008d9641396c
 
 ARG groupid=5000
 ARG userid=5000
@@ -13,7 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==0.4.0'
+    pip install --no-cache-dir 'kent==0.4.1'
 
 USER app
 


### PR DESCRIPTION
This updates kent (fakesentry service) to 0.4.1 which fixes the problem
it has with Flask 2.1.0.