### PR TITLE
bug 1762182: add support for thunderbird

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -275,12 +275,13 @@ ALL_PRODUCTS = []
 #: List of supported products; these have to match the ProductName of the
 #: incoming crash report
 MOZILLA_PRODUCTS = [
-    "Firefox",
     "Fenix",
+    "Firefox",
     "FirefoxReality",
     "Focus",
-    "ReferenceBrowser",
     "MozillaVPN",
+    "ReferenceBrowser",
+    "Thunderbird",
 ]
 
 


### PR DESCRIPTION
This adds Thunderbird to the list of supported products so the collector
accepts crash reports for it.