### PR TITLE
bug 1764571: fix data in Sentry event

### DIFF
--- a/tests/unittest/test_sentry.py
+++ b/tests/unittest/test_sentry.py
@@ -34,7 +34,7 @@ BROKEN_EVENT = {
     "exception": {
         "values": [
             {
-                "mechanism": None,
+                "mechanism": {"handled": False, "type": "antenna"},
                 "module": None,
                 "stacktrace": {
                     "frames": [
@@ -98,7 +98,7 @@ BROKEN_EVENT = {
     },
     "server_name": "",
     "timestamp": ANY,
-    "transaction": "generic WSGI request",
+    "transaction": "/__broken__",
     "transaction_info": {},
 }
 


### PR DESCRIPTION
This fixes the Sentry event to have a transaction name that makes it
easier to triage events in the Sentry interface.

This also pulls most of the Sentry configuration code into one place so
we can document how it needs to be configured.