### PR TITLE
bug 1604845: remove entropy from raw crash path

### DIFF
--- a/antenna/ext/s3/crashstorage.py
+++ b/antenna/ext/s3/crashstorage.py
@@ -29,9 +29,8 @@ class S3CrashStorage(CrashStorageBase):
                    <CRASHID>
            v2/
                raw_crash/
-                   <ENTROPY>/
-                       <YYYYMMDD>/
-                           <CRASHID>
+                   <YYYYMMDD>/
+                       <CRASHID>
 
     """
 
@@ -66,8 +65,7 @@ class S3CrashStorage(CrashStorageBase):
         self.connection.check_health(state)
 
     def _get_raw_crash_path(self, crash_id):
-        return "v2/raw_crash/{entropy}/{date}/{crash_id}".format(
-            entropy=crash_id[:3],
+        return "v2/raw_crash/{date}/{crash_id}".format(
             date=get_date_from_crash_id(crash_id),
             crash_id=crash_id,
         )

--- a/antenna/ext/s3/crashstorage.py
+++ b/antenna/ext/s3/crashstorage.py
@@ -27,7 +27,6 @@ class S3CrashStorage(CrashStorageBase):
                    <CRASHID>
                <DUMPNAME>/
                    <CRASHID>
-           v2/
                raw_crash/
                    <YYYYMMDD>/
                        <CRASHID>
@@ -65,7 +64,7 @@ class S3CrashStorage(CrashStorageBase):
         self.connection.check_health(state)
 
     def _get_raw_crash_path(self, crash_id):
-        return "v2/raw_crash/{date}/{crash_id}".format(
+        return "v1/raw_crash/{date}/{crash_id}".format(
             date=get_date_from_crash_id(crash_id),
             crash_id=crash_id,
         )

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -224,7 +224,7 @@ AWS S3 file hierarchy
 If you use the Amazon Web Services S3 crashstorage component, then crashes get
 saved in this hierarchy in the bucket:
 
-* ``/v2/raw_crash/<DATE>/<CRASHID>``
+* ``/v1/raw_crash/<DATE>/<CRASHID>``
 * ``/v1/dump_names/<CRASHID>``
 
 And then one or more dumps in directories by dump name:
@@ -237,7 +237,7 @@ For example, a crash with id ``00007bd0-2d1c-4865-af09-80bc00170413`` and
 two dumps "upload_file_minidump" and "upload_file_minidump_flash1" gets
 these files saved::
 
-    v2/raw_crash/20170413/00007bd0-2d1c-4865-af09-80bc00170413
+    v1/raw_crash/20170413/00007bd0-2d1c-4865-af09-80bc00170413
 
         Raw crash in serialized in JSON.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -224,7 +224,7 @@ AWS S3 file hierarchy
 If you use the Amazon Web Services S3 crashstorage component, then crashes get
 saved in this hierarchy in the bucket:
 
-* ``/v2/raw_crash/<ENTROPY>/<DATE>/<CRASHID>``
+* ``/v2/raw_crash/<DATE>/<CRASHID>``
 * ``/v1/dump_names/<CRASHID>``
 
 And then one or more dumps in directories by dump name:
@@ -237,7 +237,7 @@ For example, a crash with id ``00007bd0-2d1c-4865-af09-80bc00170413`` and
 two dumps "upload_file_minidump" and "upload_file_minidump_flash1" gets
 these files saved::
 
-    v2/raw_crash/000/20170413/00007bd0-2d1c-4865-af09-80bc00170413
+    v2/raw_crash/20170413/00007bd0-2d1c-4865-af09-80bc00170413
 
         Raw crash in serialized in JSON.
 

--- a/docs/spec_v1.rst
+++ b/docs/spec_v1.rst
@@ -208,7 +208,7 @@ Which gets converted to a ``raw_crash`` like this::
 
 Which ends up in S3 like this::
 
-    v2/raw_crash/000/20160513/00007bd0-2d1c-4865-af09-80bc02160513
+    v2/raw_crash/20160513/00007bd0-2d1c-4865-af09-80bc02160513
 
         Raw crash in serialized in JSON.
 

--- a/docs/spec_v1.rst
+++ b/docs/spec_v1.rst
@@ -208,7 +208,7 @@ Which gets converted to a ``raw_crash`` like this::
 
 Which ends up in S3 like this::
 
-    v2/raw_crash/20160513/00007bd0-2d1c-4865-af09-80bc02160513
+    v2/raw_crash/000/20160513/00007bd0-2d1c-4865-af09-80bc02160513
 
         Raw crash in serialized in JSON.
 
@@ -219,6 +219,13 @@ Which ends up in S3 like this::
     v1/dump/00007bd0-2d1c-4865-af09-80bc02160513
 
         Raw dump.
+
+
+.. Note::
+
+   As of September 2022, the raw_crash is now at::
+
+      v1/raw_crash/20160513/00007bd0-2d1c-4865-af09-80bc02160513
 
 
 HTTP POST request body has previously had problems with null bytes and

--- a/systemtest/conftest.py
+++ b/systemtest/conftest.py
@@ -204,7 +204,7 @@ def crash_generator():
 
 class CrashVerifier:
     def raw_crash_key(self, crash_id):
-        return "v2/raw_crash/{date}/{crashid}".format(
+        return "v1/raw_crash/{date}/{crashid}".format(
             date="20" + crash_id[-6:], crashid=crash_id
         )
 

--- a/systemtest/conftest.py
+++ b/systemtest/conftest.py
@@ -204,8 +204,8 @@ def crash_generator():
 
 class CrashVerifier:
     def raw_crash_key(self, crash_id):
-        return "v2/raw_crash/{entropy}/{date}/{crashid}".format(
-            entropy=crash_id[0:3], date="20" + crash_id[-6:], crashid=crash_id
+        return "v2/raw_crash/{date}/{crashid}".format(
+            date="20" + crash_id[-6:], crashid=crash_id
         )
 
     def dump_names_key(self, crash_id):

--- a/systemtest/test_content_length.py
+++ b/systemtest/test_content_length.py
@@ -65,11 +65,13 @@ class TestContentLength:
         )
 
     def test_content_length_20(self, posturl, crash_generator):
-        """Post a crash with a content-length 20"""
+        """Post a crash with a content-length 20 which is less than content"""
         raw_crash, dumps = crash_generator.generate()
 
         # Generate the payload and headers for a crash with no dumps
         payload, headers = mini_poster.multipart_encode(raw_crash)
+
+        assert int(headers["Content-Length"]) > 20
 
         # Add wrong content-length
         headers["Content-Length"] = "20"
@@ -78,7 +80,8 @@ class TestContentLength:
 
         assert resp.getcode() == 400
         assert (
-            str(resp.read(), encoding="utf-8") == "Discarded=malformed_no_annotations"
+            str(resp.read(), encoding="utf-8")
+            == "Discarded=malformed_invalid_payload_structure"
         )
 
     def test_content_length_1000(self, posturl, crash_generator, nginx):

--- a/systemtest/test_discards.py
+++ b/systemtest/test_discards.py
@@ -24,7 +24,8 @@ class TestDiscarded:
 
         assert resp.status_code == 400
         assert (
-            str(resp.content, encoding="utf-8") == "Discarded=malformed_no_annotations"
+            str(resp.content, encoding="utf-8")
+            == "Discarded=malformed_invalid_payload_structure"
         )
 
     def test_missing_content_type(self, posturl, s3conn, crash_generator):
@@ -71,7 +72,8 @@ class TestDiscarded:
 
         assert resp.status_code == 400
         assert (
-            str(resp.content, encoding="utf-8") == "Discarded=malformed_no_annotations"
+            str(resp.content, encoding="utf-8")
+            == "Discarded=malformed_invalid_payload_structure"
         )
 
     def test_compressed_payload_bad_header(self, posturl, s3conn, crash_generator):
@@ -88,7 +90,8 @@ class TestDiscarded:
 
         assert resp.status_code == 400
         assert (
-            str(resp.content, encoding="utf-8") == "Discarded=malformed_no_annotations"
+            str(resp.content, encoding="utf-8")
+            == "Discarded=malformed_invalid_payload_structure"
         )
 
     def test_compressed_header_non_compressed_payload(

--- a/testlib/mini_poster.py
+++ b/testlib/mini_poster.py
@@ -286,9 +286,8 @@ def cmdline(args):
             logger.info("Trying to find dump_names and dumps...")
             crashid = str(Path(parsed.raw_crash).name)
 
-            # First, raw_crash is ROOT/v2/raw_crash/ENTROPY/DATE/CRASHID, so
-            # find the root.
-            root_path = Path(parsed.raw_crash).parents[4]
+            # First, raw_crash is ROOT/v2/raw_crash/DATE/CRASHID, so find the root.
+            root_path = Path(parsed.raw_crash).parents[3]
 
             # First find dump_names which tells us about all the dumps.
             logger.info("Looking for dumps listed in dump_names...")

--- a/testlib/mini_poster.py
+++ b/testlib/mini_poster.py
@@ -277,16 +277,16 @@ def cmdline(args):
             logger.info("Adding dump %s -> %s..." % (dump_name, dump_path))
             dumps[dump_name] = open(dump_path, "rb").read()
 
-    elif "v2" in parsed.raw_crash:
-        # If there's a 'v2' in the raw_crash filename, then it's probably the
-        # case that willkg wants all the pieces for a crash he pulled from S3.
-        # We like willkg, so we'll help him out by doing the legwork.
+    elif "v1" in parsed.raw_crash:
+        # If there's a 'v1' in the raw_crash filename, then it's probably the case that
+        # willkg wants all the pieces for a crash he pulled from S3. We like willkg, so
+        # we'll help him out by doing the legwork.
         raw_crash_path = Path(parsed.raw_crash)
-        if str(raw_crash_path.parents[3]).endswith("v2"):
+        if str(raw_crash_path.parents[3]).endswith("v1"):
             logger.info("Trying to find dump_names and dumps...")
             crashid = str(Path(parsed.raw_crash).name)
 
-            # First, raw_crash is ROOT/v2/raw_crash/DATE/CRASHID, so find the root.
+            # First, raw_crash is ROOT/v1/raw_crash/DATE/CRASHID, so find the root.
             root_path = Path(parsed.raw_crash).parents[3]
 
             # First find dump_names which tells us about all the dumps.

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -51,7 +51,7 @@ class TestS3CrashStorageIntegration:
         s3mock.add_step(
             method="PUT",
             url=(
-                "http://fakes3:4569/fakebucket/v2/raw_crash/20160918/"
+                "http://fakes3:4569/fakebucket/v1/raw_crash/20160918/"
                 + "de1bb258-cbbf-4589-a673-34f800160918"
             ),
             # Not going to compare the body here because it's just the raw crash
@@ -122,7 +122,7 @@ class TestS3CrashStorageIntegration:
         s3mock.add_step(
             method="PUT",
             url=(
-                "http://fakes3:4569/fakebucket.with.periods/v2/raw_crash/20160918/"
+                "http://fakes3:4569/fakebucket.with.periods/v1/raw_crash/20160918/"
                 + "de1bb258-cbbf-4589-a673-34f800160918"
             ),
             # Not going to compare the body here because it's just the raw crash
@@ -236,7 +236,7 @@ class TestS3CrashStorageIntegration:
         s3mock.add_step(
             method="PUT",
             url=(
-                "http://fakes3:4569/fakebucket/v2/raw_crash/"
+                "http://fakes3:4569/fakebucket/v1/raw_crash/"
                 + "20160918/de1bb258-cbbf-4589-a673-34f800160918"
             ),
             # Not going to compare the body here because it's just the raw crash

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -35,7 +35,10 @@ class TestS3CrashStorageIntegration:
         # # We want to verify these files are saved in this specific order.
         s3mock.add_step(
             method="PUT",
-            url="http://fakes3:4569/fakebucket/v1/dump_names/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket/v1/dump_names/"
+                + "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             body=b'["upload_file_minidump"]',
             resp=s3mock.fake_response(status_code=200),
         )
@@ -47,7 +50,10 @@ class TestS3CrashStorageIntegration:
         )
         s3mock.add_step(
             method="PUT",
-            url="http://fakes3:4569/fakebucket/v2/raw_crash/de1/20160918/de1bb258-cbbf-4589-a673-34f800160918",
+            url=(
+                "http://fakes3:4569/fakebucket/v2/raw_crash/20160918/"
+                + "de1bb258-cbbf-4589-a673-34f800160918"
+            ),
             # Not going to compare the body here because it's just the raw crash
             resp=s3mock.fake_response(status_code=200),
         )
@@ -116,8 +122,8 @@ class TestS3CrashStorageIntegration:
         s3mock.add_step(
             method="PUT",
             url=(
-                "http://fakes3:4569/fakebucket.with.periods/v2/raw_crash/de1/20160918/"
-                "de1bb258-cbbf-4589-a673-34f800160918"
+                "http://fakes3:4569/fakebucket.with.periods/v2/raw_crash/20160918/"
+                + "de1bb258-cbbf-4589-a673-34f800160918"
             ),
             # Not going to compare the body here because it's just the raw crash
             resp=s3mock.fake_response(status_code=200),
@@ -230,8 +236,8 @@ class TestS3CrashStorageIntegration:
         s3mock.add_step(
             method="PUT",
             url=(
-                "http://fakes3:4569/fakebucket/v2/raw_crash/de1/"
-                "20160918/de1bb258-cbbf-4589-a673-34f800160918"
+                "http://fakes3:4569/fakebucket/v2/raw_crash/"
+                + "20160918/de1bb258-cbbf-4589-a673-34f800160918"
             ),
             # Not going to compare the body here because it's just the raw crash
             resp=s3mock.fake_response(status_code=200),


### PR DESCRIPTION
This removes the entropy portion from the raw crash path so it goes from this:

```
v2/raw_crash/ENTROPY/DATE/CRASHID
```
to this:
```
v1/raw_crash/DATE/CRASHID
```

That matches the work done in Socorro.

I ran the tests, posted some crash reports, and verified the contents of the bucket are in the right directory structure.