### PR TITLE
bug 1687987: switch to raw crash version 2

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -322,14 +322,11 @@ class BreakpadSubmitterResource:
         # Add timestamp to crash report
         raw_crash["submitted_timestamp"] = current_timestamp.isoformat()
 
-        # Add checksums and MinidumpSha256Hash
+        # Add checksums
         raw_crash["dump_checksums"] = {
             dump_name: hashlib.sha256(dump).hexdigest()
             for dump_name, dump in dumps.items()
         }
-        raw_crash["MinidumpSha256Hash"] = raw_crash["dump_checksums"].get(
-            "upload_file_minidump", ""
-        )
 
         # First throttle the crash which gives us the information we need
         # to generate a crash id.

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 # Production requirements
+attrs==22.1.0
 boto3==1.24.65
 botocore==1.27.65
 datadog==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,11 @@ alabaster==0.7.12 \
     --hash=sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359 \
     --hash=sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02
     # via sphinx
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via
+    #   -r requirements.in
     #   fillmore
     #   pytest
 babel==2.9.1 \

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -72,8 +72,7 @@ class TestFSCrashStorage:
         assert contents[
             "/antenna_crashes/20160918/raw_crash/de1bb258-cbbf-4589-a673-34f800160918.json"
         ] == (
-            b'{"MinidumpSha256Hash": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae", '
-            + b'"ProductName": "Test", '
+            b'{"ProductName": "Test", '
             + b'"Version": "1.0", '
             + b'"collector_notes": [], '
             + b'"dump_checksums": '

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -72,15 +72,20 @@ class TestFSCrashStorage:
         assert contents[
             "/antenna_crashes/20160918/raw_crash/de1bb258-cbbf-4589-a673-34f800160918.json"
         ] == (
-            b'{"ProductName": "Test", '
+            b"{"
+            + b'"ProductName": "Test", '
             + b'"Version": "1.0", '
+            + b'"metadata": {'
             + b'"collector_notes": [], '
             + b'"dump_checksums": '
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
             + b'"payload": "multipart", '
-            + b'"payload_compressed": "0", '
+            + b'"payload_compressed": "0"'
+            + b"}, "
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
-            + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918"}'
+            + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918", '
+            + b'"version": 2'
+            + b"}"
         )
 
         assert (


### PR DESCRIPTION
This switches to the version 2 of the raw crash structure wherein we move most of the collector-added fields into a `metadata` section and additionally add a `version` field denoting the raw crash structure version.
    
This also reworks `BreakpadSubmitterResource` so it's passing around a `CrashReport` and then generate the raw crash structure from that. That makes it a little easier to see the whole structure since it's in one place.

This also stop generating `MinidumpSha256Hash` fake annotation.

To test:

1. post a crash
2. use `s3_cli.py` to download the data and verify it's valid version 2 raw crash structure