### PR TITLE
bug 1763225: add throttle rule to raw crash metadata

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -362,7 +362,7 @@ class BreakpadSubmitterResource:
             )
             raw_crash["uuid"] = crash_id
 
-        # Log the throttle result
+        # Log throttle result and add to raw crash
         logger.info(
             "%s: matched by %s; returned %s",
             crash_id,
@@ -373,6 +373,7 @@ class BreakpadSubmitterResource:
         mymetrics.incr(
             "throttle", tags=["result:%s" % RESULT_TO_TEXT[throttle_result].lower()]
         )
+        raw_crash["metadata"]["throttle_rule"] = rule_name
 
         # If the result is REJECT, then discard it
         if throttle_result is REJECT:

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -80,7 +80,8 @@ class TestFSCrashStorage:
             + b'"dump_checksums": '
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
             + b'"payload": "multipart", '
-            + b'"payload_compressed": "0"'
+            + b'"payload_compressed": "0", '
+            + b'"throttle_rule": "accept_everything"'
             + b"}, "
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
             + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918", '


### PR DESCRIPTION
This adds the throttle rule that caused the crash to be accepted to the raw crash metadata. This lets us debug things down the road.