### PR TITLE
bug 1791209: support docker compose v2+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   main:
     docker:
-      - image: cimg/base:2022.02
+      - image: cimg/base:2023.01
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -18,7 +18,7 @@ jobs:
       - checkout
 
       - setup_remote_docker:
-          version: 20.10.11
+          version: 20.10.18
           docker_layer_caching: true
 
       - run:
@@ -26,8 +26,6 @@ jobs:
           command: |
             uname -v
             docker info
-            which docker-compose
-            docker-compose --version
 
       - run:
           name: Create version.json
@@ -61,21 +59,7 @@ jobs:
       - run:
           name: Verify requirements.txt file
           command: |
-            docker-compose run --rm --no-deps ci shell ./bin/run_verify_reqs.sh
-
-      - run:
-          name: Save image
-          # yamllint disable rule:line-length
-          command: |
-            mkdir -p workspace
-            docker save -o workspace/antenna-deploy-base.tar local/antenna_deploy_base:latest
-            gzip --fast workspace/antenna-deploy-base.tar
-          # yamllint enable rule:line-length
-
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - antenna-deploy-base.tar.gz
+            docker compose run --rm --no-deps ci shell ./bin/run_verify_reqs.sh
 
       - run:
           name: Lint

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ ifeq (1, ${NOCACHE})
 DOCKER_BUILD_OPTS := --no-cache
 endif
 
-DC := $(shell which docker-compose)
+DOCKER := $(shell which docker)
+DC=${DOCKER} compose
 
 .DEFAULT_GOAL := help
 .PHONY: help
@@ -48,8 +49,8 @@ my.env:
 
 .PHONY: build
 build: my.env  ## | Build docker images.
-	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID} deploy-base
-	${DC} build fakesentry
+	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID} --progress plain deploy-base
+	${DC} build --progress plain fakesentry
 	touch .docker-build
 
 .PHONY: setup

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ my.env:
 build: my.env  ## | Build docker images.
 	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${ANTENNA_UID} --build-arg groupid=${ANTENNA_GID} --progress plain deploy-base
 	${DC} build --progress plain fakesentry
+	${DC} build --progress plain localstack statsd
 	touch .docker-build
 
 .PHONY: setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,4 @@
 ---
-# docker-compose for antenna development.
-#
-# Note: Requires docker 1.10.0+ and docker-compose 1.6.0+.
 version: "2"
 services:
   # This builds an image of the deploy base. Then we extend that with

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,7 +13,7 @@ Antenna uses environment configuration to define its behavior.
 
 The local development environment is configured in the ``my.env`` and
 ``docker/config/local_dev.env`` env files and that configuration is pulled in
-when you run Antenna using ``docker-compose``.
+when you run Antenna using ``docker compose``.
 
 In a server environment, configuration is pulled in from the process environment.
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -18,7 +18,7 @@ is also used for local development of Antenna.
 For more comprehensive documentation or instructions on how to set this up in
 production, see documentation_.
 
-1. Install required software: Docker, docker-compose (1.10+), make, and git.
+1. Install required software: Docker, make, and git.
 
 2. Clone the repository to your local machine.
 
@@ -125,7 +125,7 @@ production, see documentation_.
 
       .. code-block:: shell
 
-         $ docker-compose ps
+         $ docker compose ps
 
       You should see containers with names ``web``, ``statsd`` and ``localstack``.
 
@@ -169,7 +169,7 @@ production, see documentation_.
 
       .. code-block:: shell
 
-         $ docker-compose run --rm web shell python bin/s3_cli.py list_buckets
+         $ docker compose run --rm web shell python bin/s3_cli.py list_buckets
 
       If you do this a lot, turn it into a shell script.
 


### PR DESCRIPTION
Previously, we supported docker-compose < v2. This changes it so that we require at least v2.