### PR TITLE
Update dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,12 +6,12 @@ datadog==0.44.0
 dockerflow==2022.8.0
 everett==3.1.0
 falcon==3.1.1
-fillmore==1.0.0
+fillmore==1.1.0
 gevent==22.10.2
 gunicorn==20.1.0
 isodate==0.6.1
 markus==4.1.0
-sentry-sdk==1.14.0
+sentry-sdk==1.19.1
 
 # Development requirements
 bandit==1.7.4
@@ -19,7 +19,7 @@ black==23.1.0
 click==8.1.3
 freezegun==1.2.2
 more-itertools==9.0.0
-pip-tools==6.12.2
+pip-tools==6.12.3
 pytest==7.2.1
 requests==2.28.2
 ruff==0.0.257

--- a/requirements.txt
+++ b/requirements.txt
@@ -140,9 +140,9 @@ falcon==3.1.1 \
     --hash=sha256:fd1eaf1a5d9d936f29f9aca3f268cf375621d1ffcbf27a6e14c187b489bf5f26 \
     --hash=sha256:ff2eaf9807ea357ced1cc60e1d2871f55aa6ea29162386efb95fb4e5a730e6de
     # via -r requirements.in
-fillmore==1.0.0 \
-    --hash=sha256:6829367ad75f10711a9b97144cb3f9a925d0c06af9c460ea28ab51f8a6d5cd80 \
-    --hash=sha256:9a7f5e3f559ee19307110e8ef094e3063cae666e698a7fe679b959e3c5eaebd4
+fillmore==1.1.0 \
+    --hash=sha256:68b2aa27340725026d7be1e4e96c3ec3ef954f66410e1cb65d0d85a692f0fdc1 \
+    --hash=sha256:8afe5fa0f59d99bc10f2996d23755860dd8b8f1aebe96c34fd5d0e5e1c2e0771
     # via -r requirements.in
 freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
@@ -378,9 +378,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via build
-pip-tools==6.12.2 \
-    --hash=sha256:6a51f4fd67140d5e83703ebfa9610fb61398727151f56a1be02a972d062e4679 \
-    --hash=sha256:8b903696df4598b10d469026ef9995c5f9a874b416e88e7a214884ebe4a70245
+pip-tools==6.12.3 \
+    --hash=sha256:480d44fae6e09fad3f9bd3d0a7e8423088715d10477e8ef0663440db25e3114f \
+    --hash=sha256:8510420f46572b2e26c357541390593d9365eb6edd2d1e7505267910ecaec080
     # via -r requirements.in
 platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
@@ -473,9 +473,9 @@ s3transfer==0.6.0 \
     --hash=sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd \
     --hash=sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947
     # via boto3
-sentry-sdk==1.14.0 \
-    --hash=sha256:273fe05adf052b40fd19f6d4b9a5556316807246bd817e5e3482930730726bb0 \
-    --hash=sha256:72c00322217d813cf493fe76590b23a757e063ff62fec59299f4af7201dd4448
+sentry-sdk==1.19.1 \
+    --hash=sha256:7ae78bd921981a5010ab540d6bdf3b793659a4db8cccf7f16180702d48a80d84 \
+    --hash=sha256:885a11c69df23e53eb281d003b9ff15a5bdfa43d8a2a53589be52104a1b4582f
     # via
     #   -r requirements.in
     #   fillmore

--- a/tests/unittest/test_sentry.py
+++ b/tests/unittest/test_sentry.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
 from unittest.mock import ANY
 
+from fillmore.test import diff_event
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -140,11 +140,8 @@ def test_sentry_scrubbing(sentry_helper):
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        # If this test fails, this will print out the new event that you can copy and
-        # paste and then edit above
-        print(json.dumps(event, indent=4, sort_keys=True))
-
-        assert event == BROKEN_EVENT
+        differences = diff_event(event, BROKEN_EVENT)
+        assert differences == []
 
 
 def test_count_sentry_scrub_error():


### PR DESCRIPTION
* fillmore: 1.0.0 -> 1.1.0
* sentry-sdk: 1.14.0 -> 1.19.1

This changes how we verify Sentry scrubbing to use `fillmore.test.diff_event` which will make it easier to discern differences.