### PR TITLE
Fix script to send example crash report.

### DIFF
--- a/bin/send_crash_report.sh
+++ b/bin/send_crash_report.sh
@@ -5,12 +5,7 @@
 
 set -euo pipefail
 
-HOST=$1
-if [ -z "${HOST}" ]; then
-    HOST="http://localhost:8000"
-fi
-
-URL="${HOST}/submit"
+URL="${1:-http://localhost:8000}/submit"
 
 curl -v -H 'Host: crash-reports' \
      -F 'uuid=a448814e-16dd-45fb-b7dd-b0b522161010' \


### PR DESCRIPTION
Since the script uses `set -u`, undefined variables are an error, so the default value for `$1` doesn't work. If no command-line argument is provided, the script errors out immediately. This change makes the default value work as expected.