### PR TITLE
bug-1882199: Verify that systemtests are using the intended backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     env_file:
       - docker/config/local_dev.env
       - docker/config/test.env
+      - my.env
     links:
       - fakesentry
       - gcs-emulator
@@ -67,6 +68,7 @@ services:
       # exclude docker/config/test.env because this will be used for systemtest
       # which requires store and publish to actually happen
       - docker/config/local_dev.env
+      - my.env
     command: web
 
   # Web container is a prod-like fully-functioning Antenna container

--- a/systemtest/conftest.py
+++ b/systemtest/conftest.py
@@ -209,15 +209,20 @@ class SQSHelper:
         return crashids
 
 
-@pytest.fixture
-def queue_helper(config):
+@pytest.fixture(params=["pubsub", "sqs"])
+def queue_helper(config, request):
     """Generate and returns a PubSub or SQS helper using env config."""
-    logger = logging.getLogger(__name__ + ".queue_helper")
+    configured_backend = "sqs"
     if (
         config("crashmover_crashpublish_class")
         == "antenna.ext.pubsub.crashpublish.PubSubCrashPublish"
     ):
-        logger.debug("using pubsub")
+        configured_backend = "pubsub"
+
+    if configured_backend != request.param:
+        pytest.skip(f"test requires {request.param}")
+
+    if configured_backend == "pubsub":
         return PubSubHelper(
             project_id=config("crashmover_crashpublish_project_id", default=""),
             topic_name=config("crashmover_crashpublish_topic_name", default=""),
@@ -225,7 +230,6 @@ def queue_helper(config):
                 "crashmover_crashpublish_subscription_name", default=""
             ),
         )
-    logger.debug("using sqs")
     return SQSHelper(
         access_key=config("crashmover_crashpublish_access_key", default=""),
         secret_access_key=config(


### PR DESCRIPTION
parameterize the fixture and skip when the param doesn't match the configured backend, showing the tested backend as part of the test name