### PR TITLE
bug-1888201: capture user-agent and put it in metadata

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -347,6 +347,10 @@ class BreakpadSubmitterResource:
             for dump_name, dump in crash_report.dumps.items()
         }
 
+        # Add User-Agent to metadata
+        user_agent = req.user_agent or "None"
+        raw_crash["metadata"]["user_agent"] = user_agent
+
         # Add version information
         raw_crash["version"] = 2
 

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -439,6 +439,7 @@ class TestBreakpadSubmitterResourceIntegration:
                 "payload_compressed": "0",
                 "payload_size": 632,
                 "throttle_rule": "is_nightly",
+                "user_agent": ANY,
             },
             "submitted_timestamp": ANY,
             "uuid": crash_id,

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -4,6 +4,7 @@
 
 import io
 import os
+from unittest.mock import ANY
 
 from freezegun import freeze_time
 import pytest
@@ -33,6 +34,7 @@ class TestFSCrashStorage:
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
             }
         )
+        headers["User-Agent"] = "wow"
 
         # Rebuild the app the test client is using with relevant configuration.
         client.rebuild_app(
@@ -83,7 +85,8 @@ class TestFSCrashStorage:
             + b'"payload": "multipart", '
             + b'"payload_compressed": "0", '
             + b'"payload_size": 645, '
-            + b'"throttle_rule": "accept_everything"'
+            + b'"throttle_rule": "accept_everything", '
+            + b'"user_agent": "wow"'
             + b"}, "
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
             + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918", '
@@ -149,6 +152,7 @@ class TestFSCrashStorage:
                 "payload_compressed": "0",
                 "payload_size": 645,
                 "throttle_rule": "accept_everything",
+                "user_agent": ANY,
             },
             "submitted_timestamp": "2011-09-06T00:00:00+00:00",
             "version": 2,

--- a/tests/unittest/test_gcs_crashstorage.py
+++ b/tests/unittest/test_gcs_crashstorage.py
@@ -176,6 +176,7 @@ class TestGcsCrashStorageIntegration:
                 "payload_compressed": "0",
                 "payload_size": 648,
                 "throttle_rule": "accept_everything",
+                "user_agent": ANY,
             },
             "submitted_timestamp": ANY,
             "uuid": "de1bb258-cbbf-4589-a673-34f800160918",

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -314,6 +314,7 @@ class TestS3CrashStorageIntegration:
                 "payload_compressed": "0",
                 "payload_size": 648,
                 "throttle_rule": "accept_everything",
+                "user_agent": ANY,
             },
             "submitted_timestamp": ANY,
             "version": 2,


### PR DESCRIPTION
Because:
* Crash reporters specify a user-agent HTTP header in the HTTP POST request when submitting crash reports.
* The Firefox crash reporter was just updated to use a Rust re-write implementation, and we'd like to know which reports are submitted by this new crash reporter.
* The new crash reporter has a unique user-agent per https://bugzilla.mozilla.org/show_bug.cgi?id=1888071#c7.

This commit:
* Captures the user-agent in crash report metadata.