### PR TITLE
bug-1881575: only require objectUser permissions for GCS

### DIFF
--- a/antenna/ext/gcs/crashstorage.py
+++ b/antenna/ext/gcs/crashstorage.py
@@ -103,7 +103,7 @@ class GcsCrashStorage(CrashStorageBase):
         :arg bytes data: the data to save
 
         """
-        bucket = self.client.get_bucket(self.bucket)
+        bucket = self.client.bucket(self.bucket)
         blob = bucket.blob(path)
         blob.upload_from_string(data)
 
@@ -115,7 +115,7 @@ class GcsCrashStorage(CrashStorageBase):
         :returns: data as bytes
 
         """
-        bucket = self.client.get_bucket(self.bucket)
+        bucket = self.client.bucket(self.bucket)
         blob = bucket.blob(path)
         return blob.download_as_bytes()
 
@@ -126,8 +126,9 @@ class GcsCrashStorage(CrashStorageBase):
     def check_health(self, state):
         """Check GCS connection health."""
         try:
-            # get the bucket to verify GCS is up and we can connect to it.
-            self.client.get_bucket(self.bucket)
+            # check if a blob exists to verify GCS is up and we can connect to it,
+            # without exceeding the permissions granted by roles/storage.objectUser
+            self.client.bucket(self.bucket).blob(generate_test_filepath()).exists()
         except Exception as exc:
             state.add_error("GcsCrashStorage", repr(exc))
 

--- a/tests/unittest/test_gcs_crashstorage.py
+++ b/tests/unittest/test_gcs_crashstorage.py
@@ -97,7 +97,7 @@ class TestGcsCrashStorageIntegration:
     @patch("google.cloud.storage.Client")
     def test_write_error(self, MockStorageClient, client):
         mock_client = MockStorageClient.return_value
-        bucket = mock_client.get_bucket.return_value
+        bucket = mock_client.bucket.return_value
         good_blob = Mock()
         bad_blob = Mock()
         bad_blob.upload_from_string.side_effect = Unauthorized("not authorized")


### PR DESCRIPTION
when deploying antenna in stage, i found it was crashing when `app.verify()` was called, and tracked that to not having get bucket permissions.

We could grant get bucket permissions, but it seems unnecessary when we could only use the permissions we need.