### PR TITLE
bug-1887640: add "cloud" to `/__version__` output

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -21,7 +21,6 @@ echo ">>> pytest"
 
 export PYTHONPATH=/app/:${PYTHONPATH:-}
 PYTEST="$(which pytest)"
-PYTHON="$(which python)"
 
 # Wait for services to be ready (both have the same endpoint url)
 urlwait "${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL}" 15

--- a/systemtest/test_dockerflow.py
+++ b/systemtest/test_dockerflow.py
@@ -17,9 +17,15 @@ class TestDockerflow:
         data = resp.json()
         assert isinstance(data, dict)
         data_keys = list(sorted(data.keys()))
-        # It's empty in the local dev environment, but has 4 keys in the server
+        # It's got "cloud" in the local dev environment and 5 keys in a server
         # environment
-        assert data_keys == [] or data_keys == ["build", "commit", "source", "version"]
+        assert data_keys == ["cloud"] or data_keys == [
+            "build",
+            "cloud",
+            "commit",
+            "source",
+            "version",
+        ]
 
     def test_heartbeat(self, baseurl):
         resp = requests.get(baseurl + "__heartbeat__", timeout=5)


### PR DESCRIPTION
This adds a "cloud" key to `/__version__` output so we can easily determine which cloud the service is running in.

To test:

1. run collector
2. check `http://localhost:8000/__version__` and make sure "cloud" value matches the cloud configuration you're using