### PR TITLE
bug-1898341: add host tag

### DIFF
--- a/antenna/__init__.py
+++ b/antenna/__init__.py
@@ -1,7 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-__author__ = "Socorro Team"
-__email__ = "socorro-dev@mozilla.com"
-__version__ = "0.1.0"

--- a/antenna/app.py
+++ b/antenna/app.py
@@ -126,7 +126,6 @@ class AntennaApp(falcon.App):
         )
         statsd_host = Option(default="localhost", doc="Hostname for statsd server.")
         statsd_port = Option(default="8125", doc="Port for statsd server.", parser=int)
-        statsd_namespace = Option(default="", doc="Namespace for statsd metrics.")
         secret_sentry_dsn = Option(
             default="",
             doc=(
@@ -214,7 +213,6 @@ class AntennaApp(falcon.App):
         setup_metrics(
             statsd_host=self.config("statsd_host"),
             statsd_port=self.config("statsd_port"),
-            statsd_namespace=self.config("statsd_namespace"),
             debug=self.config("local_dev_env"),
         )
 

--- a/antenna/app.py
+++ b/antenna/app.py
@@ -5,6 +5,7 @@
 import logging
 import logging.config
 from pathlib import Path
+import socket
 import sys
 
 from everett.manager import (
@@ -69,7 +70,7 @@ def configure_sentry(app_config):
     set_up_sentry(
         sentry_dsn=app_config("secret_sentry_dsn"),
         release=get_release_name(app_config("basedir")),
-        host_id=app_config("host_id"),
+        host_id=app_config("hostname"),
         # Disable frame-local variables
         with_locals=False,
         # Disable request data from being added to Sentry events
@@ -132,14 +133,15 @@ class AntennaApp(falcon.App):
                 "will be used instead."
             ),
         )
-        host_id = Option(
-            default="",
+        hostname = Option(
+            default=socket.gethostname(),
             doc=(
                 "Identifier for the host that is running Antenna. This identifies this Antenna "
                 "instance in the logs and makes it easier to correlate Antenna logs with "
-                "other data. For example, the value could be a public hostname, an instance id, "
-                "or something like that. If you do not set this, then socket.gethostname() is "
-                "used instead."
+                "other data. For example, the value could be a an instance id, pod id, "
+                "or something like that.\n"
+                "\n"
+                "If you do not set this, then ``socket.gethostname()`` is used instead."
             ),
         )
 
@@ -211,6 +213,7 @@ class AntennaApp(falcon.App):
         setup_metrics(
             statsd_host=self.config("statsd_host"),
             statsd_port=self.config("statsd_port"),
+            hostname=self.config("hostname"),
             debug=self.config("local_dev_env"),
         )
 
@@ -281,7 +284,7 @@ def get_app(config_manager=None):
     setup_logging(
         logging_level=app_config("logging_level"),
         debug=app_config("local_dev_env"),
-        host_id=app_config("host_id"),
+        host_id=app_config("hostname"),
         processname="antenna",
     )
 

--- a/antenna/app.py
+++ b/antenna/app.py
@@ -17,7 +17,6 @@ import falcon
 from falcon.errors import HTTPInternalServerError
 from fillmore.libsentry import set_up_sentry
 from fillmore.scrubber import Scrubber, Rule, SCRUB_RULES_DEFAULT
-import markus
 import sentry_sdk
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations.atexit import AtexitIntegration
@@ -40,11 +39,10 @@ from antenna.health_resource import (
 )
 from antenna.libdockerflow import get_release_name
 from antenna.liblogging import setup_logging, log_config
-from antenna.libmarkus import setup_metrics
+from antenna.libmarkus import setup_metrics, METRICS
 
 
 LOGGER = logging.getLogger(__name__)
-METRICS = markus.get_metrics("app")
 
 
 # Set up Sentry to scrub user ip addresses, exclude frame-local vars, exclude the
@@ -60,7 +58,7 @@ SCRUB_RULES_ANTENNA = [
 
 
 def count_sentry_scrub_error(msg):
-    METRICS.incr("sentry_scrub_error", value=1)
+    METRICS.incr("app.sentry_scrub_error", value=1)
 
 
 def configure_sentry(app_config):

--- a/antenna/crashmover.py
+++ b/antenna/crashmover.py
@@ -6,19 +6,18 @@ from dataclasses import dataclass
 import logging
 
 from everett.manager import Option, parse_class
-import markus
 
+from antenna.libmarkus import METRICS
 from antenna.util import MaxAttemptsError, retry
 
 
 LOGGER = logging.getLogger(__name__)
-MYMETRICS = markus.get_metrics("crashmover")
 
 
 def _incr_wait_generator(counter, attempts, sleep_seconds):
     def _generator_generator():
         for _ in range(attempts - 1):
-            MYMETRICS.incr(counter)
+            METRICS.incr(f"crashmover.{counter}")
             yield sleep_seconds
 
     return _generator_generator
@@ -125,7 +124,7 @@ class CrashMover:
         if hasattr(self.crashpublish, "check_health"):
             self.crashpublish.check_health(state)
 
-    @MYMETRICS.timer("crash_handling.time")
+    @METRICS.timer("crashmover.crash_handling.time")
     def handle_crashreport(self, raw_crash, dumps, crash_id):
         """Handle a new crash report synchronously and return whether that succeeded.
 
@@ -144,27 +143,27 @@ class CrashMover:
         except MaxAttemptsError:
             # After max attempts, we give up on this crash
             LOGGER.error("%s: too many errors trying to save; dropped", crash_id)
-            MYMETRICS.incr("save_crash_dropped.count")
+            METRICS.incr("crashmover.save_crash_dropped.count")
             return False
 
         try:
             self.crashmover_publish_with_retry(crash_report)
-            MYMETRICS.incr("save_crash.count")
+            METRICS.incr("crashmover.save_crash.count")
         except MaxAttemptsError:
             LOGGER.error("%s: too many errors trying to publish; dropped", crash_id)
-            MYMETRICS.incr("publish_crash_dropped.count")
+            METRICS.incr("crashmover.publish_crash_dropped.count")
             # return True even when publish fails because it will be automatically
             # published later via self-healing mechanisms
 
         return True
 
-    @MYMETRICS.timer("crash_save.time")
+    @METRICS.timer("crashmover.crash_save.time")
     def crashmover_save(self, crash_report):
         """Save crash report to storage."""
         self.crashstorage.save_crash(crash_report)
         LOGGER.info("%s saved", crash_report.crash_id)
 
-    @MYMETRICS.timer("crash_publish.time")
+    @METRICS.timer("crashmover.crash_publish.time")
     def crashmover_publish(self, crash_report):
         """Publish crash_id in publish queue."""
         self.crashpublish.publish_crash(crash_report)

--- a/antenna/libmarkus.py
+++ b/antenna/libmarkus.py
@@ -48,3 +48,6 @@ def setup_metrics(statsd_host, statsd_port, debug=False):
     markus.configure(markus_backends)
 
     _IS_MARKUS_SETUP = True
+
+
+METRICS = markus.get_metrics()

--- a/antenna/libmarkus.py
+++ b/antenna/libmarkus.py
@@ -14,12 +14,11 @@ _IS_MARKUS_SETUP = False
 LOGGER = logging.getLogger(__name__)
 
 
-def setup_metrics(statsd_host, statsd_port, statsd_namespace, debug=False):
+def setup_metrics(statsd_host, statsd_port, debug=False):
     """Initialize and configures the metrics system.
 
     :arg statsd_host: the statsd host to send metrics to
     :arg statsd_port: the port on the host to send metrics to
-    :arg statsd_namespace: the namespace (if any) for these metrics
     :arg debug: whether or not to additionally log metrics to the logger
 
     """
@@ -33,7 +32,6 @@ def setup_metrics(statsd_host, statsd_port, statsd_namespace, debug=False):
             "options": {
                 "statsd_host": statsd_host,
                 "statsd_port": statsd_port,
-                "statsd_namespace": statsd_namespace,
             },
         }
     ]

--- a/antenna/libmarkus.py
+++ b/antenna/libmarkus.py
@@ -7,22 +7,25 @@
 import logging
 
 import markus
+from markus.filters import AddTagFilter
 
 
 _IS_MARKUS_SETUP = False
 
 LOGGER = logging.getLogger(__name__)
+METRICS = markus.get_metrics()
 
 
-def setup_metrics(statsd_host, statsd_port, debug=False):
+def setup_metrics(statsd_host, statsd_port, hostname, debug=False):
     """Initialize and configures the metrics system.
 
     :arg statsd_host: the statsd host to send metrics to
     :arg statsd_port: the port on the host to send metrics to
+    :arg hostname: the host name
     :arg debug: whether or not to additionally log metrics to the logger
 
     """
-    global _IS_MARKUS_SETUP
+    global _IS_MARKUS_SETUP, METRICS
     if _IS_MARKUS_SETUP:
         return
 
@@ -45,9 +48,10 @@ def setup_metrics(statsd_host, statsd_port, debug=False):
                 },
             }
         )
+
+    if hostname:
+        METRICS.filters.append(AddTagFilter(f"host:{hostname}"))
+
     markus.configure(markus_backends)
 
     _IS_MARKUS_SETUP = True
-
-
-METRICS = markus.get_metrics()

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -27,5 +27,9 @@ urlwait "${CRASHMOVER_CRASHPUBLISH_ENDPOINT_URL}" 15
 urlwait "http://${PUBSUB_EMULATOR_HOST}" 10
 urlwait "${STORAGE_EMULATOR_HOST}/storage/v1/b" 10
 
+if [ -f metrics_emitted.txt ]; then
+    rm metrics_emitted.txt
+fi
+
 # Run tests
 "${PYTEST}" $@

--- a/tests/unittest/test_sentry.py
+++ b/tests/unittest/test_sentry.py
@@ -94,7 +94,7 @@ BROKEN_EVENT = {
         "packages": [{"name": "pypi:sentry-sdk", "version": ANY}],
         "version": ANY,
     },
-    "server_name": "",
+    "server_name": ANY,
     "timestamp": ANY,
     "transaction": "/__broken__",
     "transaction_info": {"source": "route"},


### PR DESCRIPTION
- **bug-1898341: remove statsd_namespace**
- **bug-1898341: capture metrics used in tests**
- **bug-1898341: switch to a single METRICS client**
- **bug-1898341: change HOST_ID to HOSTNAME and add host tag**

This does some minor cleanup. We don't use statsd_namespace so there's no point it having a configuration variable for it. This removes some header material from `antenna/__init__.py`.

This adds a markus backend to capture what metrics were emitted during tests. We can compare before-and-after after making fundamental changes like this to how metrics are emitted.

After I landed the `CaptureMetricsUsed` code, I captured the metrics, ran them through `sort` and `uniq` and get this:

```
histogram	breakpad_resource.crash_size	['payload:compressed']
histogram	breakpad_resource.crash_size	['payload:uncompressed']
histogram	breakpad_resource.gzipped_crash_decompress	['result:success']
incr	breakpad_resource.gzipped_crash	[]
incr	breakpad_resource.incoming_crash	[]
incr	breakpad_resource.throttle	['result:accept']
incr	breakpad_resource.throttle_rule	['rule:accept_everything']
incr	breakpad_resource.throttle_rule	['rule:is_nightly']
incr	crashmover.publish_crash_dropped.count	[]
incr	crashmover.publish_crash_exception.count	[]
incr	crashmover.save_crash.count	[]
incr	crashmover.save_crash_dropped.count	[]
incr	crashmover.save_crash_exception.count	[]
incr	health.broken.count	[]
incr	health.heartbeat.count	[]
incr	health.lbheartbeat.count	[]
incr	health.version.count	[]
timing	breakpad_resource.on_post.time	[]
timing	crashmover.crash_handling.time	[]
timing	crashmover.crash_publish.time	[]
timing	crashmover.crash_save.time	[]
```

I changed the code to use a metrics client defined in `antenna/libmarkus.py`. In doing that, I had to make changes to a lot of keys. Then I added the host tag.

That gives us this list which is the same, but with the addition of the host tag information.

```
histogram	breakpad_resource.crash_size	['payload:compressed', 'host:49c259757b46']
histogram	breakpad_resource.crash_size	['payload:compressed', 'host:7fefaf509b01']
histogram	breakpad_resource.crash_size	['payload:uncompressed', 'host:49c259757b46']
histogram	breakpad_resource.crash_size	['payload:uncompressed', 'host:7fefaf509b01']
histogram	breakpad_resource.gzipped_crash_decompress	['result:success', 'host:49c259757b46']
histogram	breakpad_resource.gzipped_crash_decompress	['result:success', 'host:7fefaf509b01']
incr	breakpad_resource.gzipped_crash	['host:49c259757b46']
incr	breakpad_resource.gzipped_crash	['host:7fefaf509b01']
incr	breakpad_resource.incoming_crash	['host:49c259757b46']
incr	breakpad_resource.incoming_crash	['host:7fefaf509b01']
incr	breakpad_resource.throttle	['result:accept', 'host:49c259757b46']
incr	breakpad_resource.throttle	['result:accept', 'host:7fefaf509b01']
incr	breakpad_resource.throttle_rule	['rule:accept_everything', 'host:49c259757b46']
incr	breakpad_resource.throttle_rule	['rule:accept_everything', 'host:7fefaf509b01']
incr	breakpad_resource.throttle_rule	['rule:is_nightly', 'host:49c259757b46']
incr	breakpad_resource.throttle_rule	['rule:is_nightly', 'host:7fefaf509b01']
incr	crashmover.publish_crash_dropped.count	['host:49c259757b46']
incr	crashmover.publish_crash_dropped.count	['host:7fefaf509b01']
incr	crashmover.publish_crash_exception.count	['host:49c259757b46']
incr	crashmover.publish_crash_exception.count	['host:7fefaf509b01']
incr	crashmover.save_crash.count	['host:49c259757b46']
incr	crashmover.save_crash.count	['host:7fefaf509b01']
incr	crashmover.save_crash_dropped.count	['host:49c259757b46']
incr	crashmover.save_crash_dropped.count	['host:7fefaf509b01']
incr	crashmover.save_crash_exception.count	['host:49c259757b46']
incr	crashmover.save_crash_exception.count	['host:7fefaf509b01']
incr	health.broken.count	['host:49c259757b46']
incr	health.broken.count	['host:7fefaf509b01']
incr	health.heartbeat.count	['host:49c259757b46']
incr	health.heartbeat.count	['host:7fefaf509b01']
incr	health.lbheartbeat.count	['host:49c259757b46']
incr	health.lbheartbeat.count	['host:7fefaf509b01']
incr	health.version.count	['host:49c259757b46']
incr	health.version.count	['host:7fefaf509b01']
timing	breakpad_resource.on_post.time	['host:49c259757b46']
timing	breakpad_resource.on_post.time	['host:7fefaf509b01']
timing	crashmover.crash_handling.time	['host:49c259757b46']
timing	crashmover.crash_handling.time	['host:7fefaf509b01']
timing	crashmover.crash_publish.time	['host:49c259757b46']
timing	crashmover.crash_publish.time	['host:7fefaf509b01']
timing	crashmover.crash_save.time	['host:49c259757b46']
timing	crashmover.crash_save.time	['host:7fefaf509b01']
```

That's not quite what we want. It adds the `host` tag for both AWS and GCP environments. However, I think that'll be ok.

Pretty sure we can see the hostname value in Sentry since it gets passed into the sentry init function.

* Antenna: `ec2-18-234-116-224.compute-1.amazonaws.com_i-04a52c01b39074c53`
* Tecken: `ip-172-31-59-195.ec2.internal`

If we look at Grafana, we see the values that telegraf is putting in.

* Antenna: `ip-172-31-23-117.us-west-2.compute.internal`
* Tecken: `ip-172-31-12-209.us-west-2.compute.internal`

I implemented the Antenna hostname thing much like we have Tecken:

* configuration key is "HOSTNAME"
* if it's not set, the value defaults to `socket.gethostname()`
* we don't set it in the infrastructure code

Given that, I think even though this implementation adds a `host` tag for both AWS and GCP environments, it'll be fine.