### PR TITLE
bug-1898345: fix metrics key prefix

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -59,7 +59,7 @@ SCRUB_RULES_ANTENNA = [
 
 
 def count_sentry_scrub_error(msg):
-    METRICS.incr("app.sentry_scrub_error", value=1)
+    METRICS.incr("collector.sentry_scrub_error", value=1)
 
 
 def configure_sentry(app_config):

--- a/antenna/crashmover.py
+++ b/antenna/crashmover.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 def _incr_wait_generator(counter, attempts, sleep_seconds):
     def _generator_generator():
         for _ in range(attempts - 1):
-            METRICS.incr(f"crashmover.{counter}")
+            METRICS.incr(f"collector.crashmover.{counter}")
             yield sleep_seconds
 
     return _generator_generator
@@ -124,7 +124,7 @@ class CrashMover:
         if hasattr(self.crashpublish, "check_health"):
             self.crashpublish.check_health(state)
 
-    @METRICS.timer("crashmover.crash_handling.time")
+    @METRICS.timer("collector.crashmover.crash_handling.time")
     def handle_crashreport(self, raw_crash, dumps, crash_id):
         """Handle a new crash report synchronously and return whether that succeeded.
 
@@ -143,27 +143,27 @@ class CrashMover:
         except MaxAttemptsError:
             # After max attempts, we give up on this crash
             LOGGER.error("%s: too many errors trying to save; dropped", crash_id)
-            METRICS.incr("crashmover.save_crash_dropped.count")
+            METRICS.incr("collector.crashmover.save_crash_dropped.count")
             return False
 
         try:
             self.crashmover_publish_with_retry(crash_report)
-            METRICS.incr("crashmover.save_crash.count")
+            METRICS.incr("collector.crashmover.save_crash.count")
         except MaxAttemptsError:
             LOGGER.error("%s: too many errors trying to publish; dropped", crash_id)
-            METRICS.incr("crashmover.publish_crash_dropped.count")
+            METRICS.incr("collector.crashmover.publish_crash_dropped.count")
             # return True even when publish fails because it will be automatically
             # published later via self-healing mechanisms
 
         return True
 
-    @METRICS.timer("crashmover.crash_save.time")
+    @METRICS.timer("collector.crashmover.crash_save.time")
     def crashmover_save(self, crash_report):
         """Save crash report to storage."""
         self.crashstorage.save_crash(crash_report)
         LOGGER.info("%s saved", crash_report.crash_id)
 
-    @METRICS.timer("crashmover.crash_publish.time")
+    @METRICS.timer("collector.crashmover.crash_publish.time")
     def crashmover_publish(self, crash_report):
         """Publish crash_id in publish queue."""
         self.crashpublish.publish_crash(crash_report)

--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -17,7 +17,7 @@ class BrokenResource:
 
     def on_get(self, req, resp):
         """Implement GET HTTP request."""
-        METRICS.incr("health.broken.count")
+        METRICS.incr("collector.health.broken.count")
         # This is intentional breakage
         raise Exception("intentional exception")
 
@@ -30,7 +30,7 @@ class VersionResource:
 
     def on_get(self, req, resp):
         """Implement GET HTTP request."""
-        METRICS.incr("health.version.count")
+        METRICS.incr("collector.health.version.count")
         version_info = get_version_info(self.basedir)
         # FIXME(willkg): there's no cloud provider environment variable to use, so
         # we'll cheat and look at whether there's a "gcs" in
@@ -52,7 +52,7 @@ class LBHeartbeatResource:
 
     def on_get(self, req, resp):
         """Implement GET HTTP request."""
-        METRICS.incr("health.lbheartbeat.count")
+        METRICS.incr("collector.health.lbheartbeat.count")
         resp.content_type = "application/json; charset=utf-8"
         resp.status = falcon.HTTP_200
 
@@ -94,7 +94,7 @@ class HeartbeatResource:
 
     def on_get(self, req, resp):
         """Implement GET HTTP request."""
-        METRICS.incr("health.heartbeat.count")
+        METRICS.incr("collector.health.heartbeat.count")
         state = HealthState()
 
         # So we're going to think of Antenna like a big object graph and
@@ -107,7 +107,7 @@ class HeartbeatResource:
 
         # Go through and call gauge for each statsd item.
         for key, value in state.statsd.items():
-            METRICS.gauge(f"health.{key}", value=value)
+            METRICS.gauge(f"collector.health.{key}", value=value)
 
         if state.is_healthy():
             resp.status = falcon.HTTP_200

--- a/antenna/libmarkus.py
+++ b/antenna/libmarkus.py
@@ -13,7 +13,7 @@ from markus.filters import AddTagFilter
 _IS_MARKUS_SETUP = False
 
 LOGGER = logging.getLogger(__name__)
-METRICS = markus.get_metrics()
+METRICS = markus.get_metrics("socorro")
 
 
 def setup_metrics(statsd_host, statsd_port, hostname, debug=False):

--- a/tests/unittest/test_sentry.py
+++ b/tests/unittest/test_sentry.py
@@ -146,4 +146,4 @@ def test_count_sentry_scrub_error():
     with MetricsMock() as metricsmock:
         metricsmock.clear_records()
         count_sentry_scrub_error("foo")
-        metricsmock.assert_incr("app.sentry_scrub_error", value=1)
+        metricsmock.assert_incr("socorro.collector.sentry_scrub_error", value=1)


### PR DESCRIPTION
In bec86e31, I removed setting the `statsd_prefix` because I thought we were adding `"socorro.collector"` in telegraf--not in DatadogMetrics markus backend. That was wrong and I broke stats in Socorro stage AWS.

This fixes that by setting `"socorro"` in the `MetricsInterface` per our convention and then fixing the keys to include `"collector"`.

Then I discovered one of the tests was busted, so I fixed that. I also added metrics assertions to `test_submit_crash_report`.

The host value can change, so I wrote an `AnyTagValue` class that'll let us assert a tag was emitted with whatever value it has. I'll move that to Markus in https://github.com/willkg/markus/issues/141 at some point.