### PR TITLE
Configure gunicorn to emit statsd metrics

### DIFF
--- a/bin/run_web.sh
+++ b/bin/run_web.sh
@@ -14,12 +14,18 @@ GUNICORN_WORKER_CLASS=${GUNICORN_WORKER_CLASS:-"sync"}
 GUNICORN_MAX_REQUESTS=${GUNICORN_MAX_REQUESTS:-"0"}
 GUNICORN_MAX_REQUESTS_JITTER=${GUNICORN_MAX_REQUESTS_JITTER:-"0"}
 CMD_PREFIX=${CMD_PREFIX:-""}
+STATSD_HOST=${STATSD_HOST:-localhost}
+STATSD_PORT=${STATSD_PORT:-8125}
+HOSTNAME=${HOSTNAME:-$(hostname)}
 
 ${CMD_PREFIX} gunicorn \
     --workers="${GUNICORN_WORKERS}" \
     --worker-class="${GUNICORN_WORKER_CLASS}" \
     --max-requests="${GUNICORN_MAX_REQUESTS}" \
     --max-requests-jitter="${GUNICORN_MAX_REQUESTS_JITTER}" \
+    --statsd-host=${STATSD_HOST}:${STATSD_PORT} \
+    --statsd-prefix=socorro.collector \
+    --dogstatsd-tags=host:$HOSTNAME \
     --log-file=- \
     --error-logfile=- \
     --access-logfile=- \


### PR DESCRIPTION
to help investigate ongoing http 502 incident