### PR TITLE
Update sentry-sdk to 2.6.0, fillmore to 2.0.0, and kent to 2.0.0

### DIFF
--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -16,7 +16,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==1.2.0'
+    pip install --no-cache-dir 'kent==2.0.0'
 
 USER kent
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,12 +6,12 @@ datadog==0.49.1
 dockerflow==2024.4.2
 everett==3.3.0
 falcon==3.1.3
-fillmore==1.2.0
+fillmore==2.0.0
 google-cloud-storage==2.16.0
 gunicorn==22.0.0
 isodate==0.6.1
 markus==4.2.0
-sentry-sdk==1.45.0
+sentry-sdk==2.6.0
 google-cloud-pubsub==2.21.1
 
 # Development requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -198,9 +198,9 @@ falcon==3.1.3 \
     --hash=sha256:e19a0a3827821bcf754a9b24217e3b8b4750f7eb437c4a8c461135a86ca9b1c5 \
     --hash=sha256:e1f622d73111912021b8311d1e5d1eabef484217d2d30abe3d237533cb225ce9
     # via -r requirements.in
-fillmore==1.2.0 \
-    --hash=sha256:1968a2ba5adc17ebef362df51ec958c3d78427a77d2218a2709aabc3598eeceb \
-    --hash=sha256:c95f7172614c256fe162e93ae6d5beb07e45e1fe7f71b94f5a08eab45dc58a40
+fillmore==2.0.0 \
+    --hash=sha256:840901d80799ce50db49c3e377815424a356c3e81c6cea5111684c58113d7ad1 \
+    --hash=sha256:fd1a2c2e829073cef3d49f032033d78dbee48f377eb4b915f29084e76f6facb4
     # via -r requirements.in
 freezegun==1.5.0 \
     --hash=sha256:200a64359b363aa3653d8aac289584078386c7c3da77339d257e46a01fb5c77c \
@@ -664,9 +664,9 @@ s3transfer==0.10.1 \
     --hash=sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19 \
     --hash=sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d
     # via boto3
-sentry-sdk==1.45.0 \
-    --hash=sha256:1ce29e30240cc289a027011103a8c83885b15ef2f316a60bcc7c5300afa144f1 \
-    --hash=sha256:509aa9678c0512344ca886281766c2e538682f8acfa50fd8d405f8c417ad0625
+sentry-sdk==2.6.0 \
+    --hash=sha256:422b91cb49378b97e7e8d0e8d5a1069df23689d45262b86f54988a7db264e874 \
+    --hash=sha256:65cc07e9c6995c5e316109f138570b32da3bd7ff8d0d0ee4aaf2628c3dd8127d
     # via
     #   -r requirements.in
     #   fillmore

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -4,7 +4,7 @@
 
 from unittest.mock import ANY
 
-from fillmore.test import diff_event
+from fillmore.test import diff_structure
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -133,12 +133,12 @@ def test_sentry_scrubbing(sentry_helper):
         )
         assert resp.status_code == 500
 
-        (event,) = sentry_client.events
+        (event,) = sentry_client.envelope_payloads
 
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        differences = diff_event(event, BROKEN_EVENT)
+        differences = diff_structure(event, BROKEN_EVENT)
         assert differences == []
 
 


### PR DESCRIPTION
This updates fillmore and kent to 2.0.0 which support the API changes in sentry-sdk >= 2.

kent 2.0.0 API changes: https://github.com/willkg/kent/releases/tag/v2.0.0

fillmore 2.0.0 API changes: https://github.com/willkg/fillmore/releases/tag/v2.0.0