### PR TITLE
Don't use custom docker compose services for CI

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,6 +18,9 @@ jobs:
       deployments: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      # Disable docker compose volume mounts in docker-compose.override.yml
+      COMPOSE_FILE: docker-compose.yml
     steps:
       - uses: actions/checkout@v4
       - name: Get info
@@ -39,20 +42,20 @@ jobs:
         run: make build
       - name: Verify requirements.txt contains correct dependencies
         run: |
-          docker compose run --rm --no-deps ci shell ./bin/run_verify_reqs.sh
+          docker compose run --rm --no-deps test shell ./bin/run_verify_reqs.sh
       - name: Run lint check
         run: |
           make my.env
-          docker compose run --rm --no-deps ci shell ./bin/run_lint.sh
+          docker compose run --rm --no-deps test shell ./bin/run_lint.sh
       - name: Run tests
         run: |
           make my.env
-          docker compose run --rm ci shell ./bin/run_tests.sh
+          docker compose run --rm test shell ./bin/run_tests.sh
       - name: Run systemtest
         run: |
-          docker compose run --rm ci-web shell ./bin/run_setup.sh
-          docker compose up --detach --wait --wait-timeout=10 ci-web
-          docker compose run --rm ci-web shell bash -c 'cd systemtest && NGINX_TESTS=0 POST_CHECK=1 HOST=http://ci-web:8000 pytest -vv'
+          make setup
+          docker compose up --detach --wait --wait-timeout=10 web
+          docker compose run --rm web shell systemtest/test_env.sh local
 
       - name: Set Docker image tag to "latest" for updates of the main branch
         if: github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,5 @@ target/
 # Docker things
 /.docker-build
 /fakes3_root/
-docker-compose.override.yml
 my.env
 .env

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+---
+services:
+  base:
+    # define volumes in docker-compose.override.yml so that can be ignored in CI
+    volumes:
+      - .:/app
+  test:
+    volumes:
+      - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
   # building docs.
   base:
     image: local/antenna_deploy_base
-    volumes:
-      - .:/app
 
   # Test container
   test:
@@ -31,8 +29,6 @@ services:
       - gcs-emulator
       - pubsub
       - statsd
-    volumes:
-      - .:/app
 
   devcontainer:
     build:
@@ -52,34 +48,6 @@ services:
       - statsd
     volumes:
       - .:/app
-
-  # Container that we use in CI--it can't volume mount things
-  ci:
-    image: local/antenna_deploy_base
-    env_file:
-      - docker/config/local_dev.env
-      - docker/config/test.env
-      - my.env
-    links:
-      - fakesentry
-      - gcs-emulator
-      - pubsub
-      - statsd
-
-  # like web but CI can't volume mount things
-  ci-web:
-    image: local/antenna_deploy_base
-    env_file:
-      # exclude docker/config/test.env because this will be used for systemtest
-      # which requires store and publish to actually happen
-      - docker/config/local_dev.env
-      - my.env
-    command: web
-    links:
-      - fakesentry
-      - gcs-emulator
-      - pubsub
-      - statsd
 
   # Web container is a prod-like fully-functioning Antenna container
   web:


### PR DESCRIPTION
by defining volume mounts in `docker-compose.override.yml` they are used by default in the dev environment, but can be disabled for CI by setting `COMPOSE_FILE`. This reduces the differences between dev and CI, which allows CI to take advantage of commands like `make setup` and `systemtest/test_env.sh local`.

This makes `docker-compose.override.yml` no longer ignored by git, which may be undesirable. If that's not acceptable, we could use the services with volume mounts in CI, because github actions support that (unlike circleci). That would require specifying `--user="$(id --user):$(id --group)"` in CI for `docker compose run` commands that touch /app to avoid permissions issues (note: I also tested this solution, it works).