### PR TITLE
Fix web container to mount volume in local dev environment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,10 @@
 ---
+# define volumes in docker-compose.override.yml so that can be ignored in CI
 services:
   base:
-    # define volumes in docker-compose.override.yml so that can be ignored in CI
+    volumes:
+      - .:/app
+  web:
     volumes:
       - .:/app
   test:


### PR DESCRIPTION
This fixes the web container so that it mounts the repo directory as `/app` which allows us to see code changes without having to rebuild.

I think what's going on is that the override for `base` doesn't get pulled into the services that extend `base`.