### PR TITLE
OBS-361: Configure stop signals for Docker containers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
         groupid: ${USE_GID:-10001}
     image: local/antenna-devcontainer
     entrypoint: ["sleep", "inf"]
+    stop_signal: SIGKILL  # Doesn't seem to respond to anything else
     env_file:
       - docker/config/local_dev.env
       - docker/config/test.env
@@ -75,6 +76,7 @@ services:
       - pubsub
       - start
       - --host-port=0.0.0.0:${PUBSUB_PORT:-5010}
+    stop_signal: SIGINT
     ports:
       - "${EXPOSE_PUBSUB_EMULATOR_PORT:-5010}:5010"
 


### PR DESCRIPTION
The devcontainer and pubsub container don't respond to the SIGTERM signal sent by Docker Compose by default. To speed up container shutdown, we configure signals that actually do to be sent in the first attempt.

(Antenna did not use tini, so I didn't need to remove it.)

https://mozilla-hub.atlassian.net/browse/OBS-361