### PR TITLE
Prevent dependabot from proposing Python version upgrades beyond 3.11.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       interval: "weekly"
     rebase-strategy: "disabled"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: python
+        versions: [">=3.12"]
 
   # Set update schedule for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# This should be kept in sync with the python version used in .devcontainer/Dockerfile and
-# docker/images/fakesentry/Dockerfile
+# NOTE(smarnach): To upgrade Python to a new minor or major version, see
+# https://antenna.readthedocs.io/en/latest/dev.html#upgrading-to-a-new-python-version
 FROM --platform=linux/amd64 python:3.11.10-slim-bullseye@sha256:f6a64ef0a5cc14855b15548056a8fc77f4c3526b79883fa6709a8e23f676ac34
 
 # Set up user and group

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -535,3 +535,17 @@ pick up changes:
 .. code-block:: shell
 
    $ make devcontainer
+
+
+Upgrading to a new Python version
+=================================
+
+To upgrade Python to a new minor or major version, you need to change the version in
+these files:
+
+* ``.devcontainer/Dockerfile``
+* ``.github/dependabot.yml``
+* ``.readthedocs.yaml``
+* ``docker/Dockerfile``
+* ``docker/images/fakesentry/Dockerfile``
+* ``pyproject.toml``


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/OBS-375