### PR TITLE
Fix dependabot updates for docker/images/*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directories:
+      - "/docker"
+      - "/docker/images/fakesentry"
+      - "/docker/images/gcs-emulator"
+      - "/docker/images/nginx"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,7 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "/docker"
-      - "/docker/images/fakesentry"
-      - "/docker/images/gcs-emulator"
-      - "/docker/images/nginx"
+      - "/docker/images/*"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"


### PR DESCRIPTION
switches from directory to directories, as documented here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories

directories explicitly supports wildcards