### PR TITLE
OBS-361: Remove tini from Docker containers.

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -25,13 +25,13 @@ shift
 
 case ${SERVICE} in
 web)  ## Run web service
-    /app/bin/run_web.sh "$@"
+    exec /app/bin/run_web.sh "$@"
     ;;
 shell)  ## Open a shell or run something else
-    if [ -z "$*" ]; then
-        bash
+    if [ $# -eq 0 ]; then
+        exec bash
     else
-        "$@"
+        exec "$@"
     fi
     ;;
 *)

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -31,4 +31,4 @@ if [ -f metrics_emitted.txt ]; then
 fi
 
 # Run tests
-"${PYTEST}" $@
+exec "${PYTEST}" "$@"

--- a/bin/run_web.sh
+++ b/bin/run_web.sh
@@ -18,7 +18,7 @@ STATSD_HOST=${STATSD_HOST:-localhost}
 STATSD_PORT=${STATSD_PORT:-8125}
 HOSTNAME=${HOSTNAME:-$(hostname)}
 
-${CMD_PREFIX} gunicorn \
+exec ${CMD_PREFIX} gunicorn \
     --workers="${GUNICORN_WORKERS}" \
     --worker-class="${GUNICORN_WORKER_CLASS}" \
     --max-requests="${GUNICORN_MAX_REQUESTS}" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
     ports:
       - "${EXPOSE_SENTRY_PORT:-8090}:8090"
     command: run --host 0.0.0.0 --port 8090
+    stop_signal: SIGINT
 
   # https://github.com/fsouza/fake-gcs-server
   # Fake GCP GCS server for local development and testing

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,7 @@ RUN apt-get update && \
         apt-transport-https \
         build-essential \
         git \
-        gcc \
-        tini && \
+        gcc && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -40,4 +39,4 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PORT 8000
 EXPOSE $PORT
 
-ENTRYPOINT ["tini", "--", "/app/bin/entrypoint.sh"]
+ENTRYPOINT ["/app/bin/entrypoint.sh"]


### PR DESCRIPTION
I noticed that I missed a bunch of things for Antenna when working on OBS-361, so here's an amendment. The changes are similar to what I did for all other services:

* Remove tini.
* Set stop signals where appropriate.
* Use `exec` in scripts where appropriate.

https://mozilla-hub.atlassian.net/browse/OBS-361