### PR TITLE
obs-541: remove statsd namespace in local dev environment

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -10,7 +10,6 @@ LOGGING_LEVEL=DEBUG
 
 # Statsd settings
 STATSD_HOST=statsd
-STATSD_NAMESPACE=mcboatface
 
 # Crashmover settings
 CRASHMOVER_CRASHSTORAGE_CLASS=antenna.ext.gcs.crashstorage.GcsCrashStorage


### PR DESCRIPTION
Previously, we used `STATSD_NAMESPACE` and set it in the local dev environment. We don't want to do that anymore since the application now emits full metrics keys. This removes the fake `STATSD_NAMESPACE` value from the local dev environment.

This mirrors https://github.com/mozilla-services/tecken/pull/3132 .