### PR TITLE
bug-1964356: Restrict pip to a version earlier than 25.1.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
 
 # Install Python dependencies
 COPY requirements.txt /app/
+# NOTE(smarnach): Unpin pip once https://github.com/jazzband/pip-tools/issues/2176 is resolved.
 RUN pip install -U 'pip>=20' && \
     pip install --no-cache-dir --no-deps --only-binary :all: -r requirements.txt && \
     pip install --no-cache-dir ipython && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 COPY --chown=app:app requirements.txt /app/
 
-RUN pip install -U 'pip>=20' && \
+RUN pip install -U 'pip<25.1' && \
     pip install --no-cache-dir --no-deps --only-binary :all: -r requirements.txt && \
     pip check --disable-pip-version-check
 

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ bandit==1.8.3
 click==8.1.8
 freezegun==1.5.1
 more-itertools==10.6.0
+# NOTE(smarnach): Unpin pip in docker/Dockerfile once https://github.com/jazzband/pip-tools/issues/2176 is resolved.
 pip-tools==7.4.1
 pytest==8.3.5
 requests==2.32.3


### PR DESCRIPTION
Use an earlier version of pip becuase of https://github.com/jazzband/pip-tools/issues/2176.